### PR TITLE
Add node name under Spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,9 @@ $ cat deploy/crds/kubevirt_v1alpha1_nodemaintenance_cr.yaml
 apiVersion: kubevirt.io/v1alpha1
 kind: NodeMaintenance
 metadata:
-  name: node02
+  name: nodemaintenance-xyz
 spec:
+  nodeName: node02
   reason: "Test node maintenance"
 
 $ kubectl apply -f deploy/crds/cache_v1alpha1_memcached_cr.yaml
@@ -121,8 +122,9 @@ $ cat deploy/crds/kubevirt_v1alpha1_nodemaintenance_cr.yaml
 apiVersion: kubevirt.io/v1alpha1
 kind: NodeMaintenance
 metadata:
-  name: node02
+  name: nodemaintenance-xyz
 spec:
+  nodeName: node02
   reason: "Test node maintenance"
 
 $ kubectl delete -f deploy/crds/cache_v1alpha1_memcached_cr.yaml

--- a/deploy/crds/kubevirt_v1alpha1_nodemaintenance_crd.yaml
+++ b/deploy/crds/kubevirt_v1alpha1_nodemaintenance_crd.yaml
@@ -24,8 +24,12 @@ spec:
           type: object
         spec:
           properties:
+            nodeName:
+              type: string
             reason:
               type: string
+          required:
+          - nodeName
           type: object
         status:
           properties:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -18,7 +18,7 @@ spec:
       containers:
         - name: node-maintenance-operator
           # Replace this with the built image name
-          image: quay.io/yanirq/node-maintenance-operator:v0.0.1
+          image: quay.io/kubevirt/node-maintenance-operator:latest
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE

--- a/pkg/apis/kubevirt/v1alpha1/nodemaintenance_types.go
+++ b/pkg/apis/kubevirt/v1alpha1/nodemaintenance_types.go
@@ -4,9 +4,16 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	NodeMaintenanceFinalizer string = "foregroundDeleteNodeMaintenance"
+)
+
 // NodeMaintenanceSpec defines the desired state of NodeMaintenance
 // +k8s:openapi-gen=true
 type NodeMaintenanceSpec struct {
+	// Node name to apply maintanance on/off
+	NodeName string `json:"nodeName"`
+	// Reason for maintanance
 	Reason string `json:"reason,omitempty"`
 }
 

--- a/pkg/apis/kubevirt/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/kubevirt/v1alpha1/zz_generated.openapi.go
@@ -68,13 +68,22 @@ func schema_pkg_apis_kubevirt_v1alpha1_NodeMaintenanceSpec(ref common.ReferenceC
 			SchemaProps: spec.SchemaProps{
 				Description: "NodeMaintenanceSpec defines the desired state of NodeMaintenance",
 				Properties: map[string]spec.Schema{
+					"nodeName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Node name to apply maintanance on/off",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"reason": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "Reason for maintanance",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},
+				Required: []string{"nodeName"},
 			},
 		},
 		Dependencies: []string{},

--- a/pkg/controller/nodemaintenance/taint.go
+++ b/pkg/controller/nodemaintenance/taint.go
@@ -1,11 +1,14 @@
 package nodemaintenance
 
 import (
-	"context"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/json"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	kubernetes "k8s.io/client-go/kubernetes"
 	taintutils "k8s.io/kubernetes/pkg/util/taints"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var taint = &corev1.Taint{
@@ -13,32 +16,53 @@ var taint = &corev1.Taint{
 	Effect: corev1.TaintEffectNoSchedule,
 }
 
-func addTaint(c client.Client, node *corev1.Node) (bool, error) {
-	freshNode, updated, err := taintutils.AddOrUpdateTaint(node, taint)
-	if err != nil {
-		return false, err
-	}
-	if updated {
-		err = c.Update(context.TODO(), freshNode)
-		if err != nil {
-			return false, err
-		}
-		return true, nil
-	}
-	return false, nil
-}
+func AddOrRemoveTaint(clientset kubernetes.Interface, node *corev1.Node, add bool) error {
 
-func removeTaint(c client.Client, node *corev1.Node) (bool, error) {
-	freshNode, updated, err := taintutils.RemoveTaint(node, taint)
+	taintStr := ""
+	freshNode := &corev1.Node{}
+	updated := false
+
+	client := clientset.Core().Nodes()
+	oldData, err := json.Marshal(node)
 	if err != nil {
-		return false, err
+		return err
 	}
-	if updated {
-		err = c.Update(context.TODO(), freshNode)
-		if err != nil {
-			return false, err
-		}
-		return true, nil
+
+	if add {
+		taintStr = "add"
+		freshNode, updated, err = taintutils.AddOrUpdateTaint(node, taint)
+
+	} else {
+		taintStr = "remove"
+		freshNode, updated, err = taintutils.RemoveTaint(node, taint)
+
 	}
-	return false, nil
+
+	log.Info(fmt.Sprintf("Applying %s taint %s on Node: %s", taint.Key, taintStr, node.Name))
+
+	if !updated {
+		log.Error(err, fmt.Sprintf("%s taint %s was not applied on Node: %s", taint.Key, taintStr, node.Name))
+	}
+
+	if err != nil {
+		return err
+	}
+
+	newData, err := json.Marshal(freshNode)
+	if err != nil {
+		return err
+	}
+
+	patchBytes, patchErr := strategicpatch.CreateTwoWayMergePatch(oldData, newData, node)
+	if patchErr == nil {
+		_, err = client.Patch(node.Name, types.StrategicMergePatchType, patchBytes)
+	} else {
+		_, err = client.Update(node)
+	}
+
+	if patchErr != nil {
+		log.Error(err, fmt.Sprintf("%s taint %s was not applied on Node: %s", taint.Key, taintStr, node.Name))
+	}
+
+	return err
 }

--- a/pkg/controller/nodemaintenance/utils.go
+++ b/pkg/controller/nodemaintenance/utils.go
@@ -1,0 +1,22 @@
+package nodemaintenance
+
+// ContainsString checks if the string array contains the given string.
+func ContainsString(slice []string, s string) bool {
+	for _, item := range slice {
+		if item == s {
+			return true
+		}
+	}
+	return false
+}
+
+// RemoveString removes the given string from the string array if exists.
+func RemoveString(slice []string, s string) (result []string) {
+	for _, item := range slice {
+		if item == s {
+			continue
+		}
+		result = append(result, item)
+	}
+	return
+}

--- a/test/e2e/nodemaintenance_test.go
+++ b/test/e2e/nodemaintenance_test.go
@@ -98,11 +98,12 @@ func nodeMaintenanceTest(t *testing.T, f *framework.Framework, ctx *framework.Te
 			APIVersion: "kubevirt.io/v1alpha1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      nodeName,
+			Name:      "nodeMaintenance",
 			Namespace: namespace,
 		},
 		Spec: operator.NodeMaintenanceSpec{
-			Reason: "Set maintenance on node for e2e testing",
+			NodeName: nodeName,
+			Reason:   "Set maintenance on node for e2e testing",
 		},
 	}
 

--- a/test/e2e/nodemaintenance_test.go
+++ b/test/e2e/nodemaintenance_test.go
@@ -98,7 +98,7 @@ func nodeMaintenanceTest(t *testing.T, f *framework.Framework, ctx *framework.Te
 			APIVersion: "kubevirt.io/v1alpha1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "nodeMaintenance",
+			Name:      "nodemaintenance-xyz",
 			Namespace: namespace,
 		},
 		Spec: operator.NodeMaintenanceSpec{
@@ -156,10 +156,17 @@ func nodeMaintenanceTest(t *testing.T, f *framework.Framework, ctx *framework.Te
 
 	t.Logf("Setting node %s out of maintanance", nodeName)
 
-	// Delete the node maintenance custom resource
-	err = f.Client.Delete(goctx.TODO(), nodeMaintenance)
+	nodeMaintenanceDelete := &operator.NodeMaintenance{}
+
+	err = f.Client.Get(goctx.TODO(), types.NamespacedName{Namespace: nodeMaintenance.Namespace, Name: nodeMaintenance.Name}, nodeMaintenanceDelete)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	// Delete the node maintenance custom resource
+	err = f.Client.Delete(goctx.TODO(), nodeMaintenanceDelete)
+	if err != nil {
+		t.Fatalf("Could not delete node maintenance CR : %v", err)
 	}
 
 	time.Sleep(60 * time.Second)


### PR DESCRIPTION
Changed scheme for NodeMaintenance CR to support the following structure:

apiVersion: kubevirt.io/v1alpha1
kind: NodeMaintenance
metadata:
  name: nodemaintenance-xyz
spec:
  nodeName: node02
  reason: "Test node maintenance"

fixes #3 