### PR TITLE
Add csv-generator script to operator container image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ gen-k8s-check: $(apis_sources)
 
 container-build: container-build-operator container-build-registry
 
-container-build-operator:
+container-build-operator: csv-generator
 	docker build -f build/Dockerfile -t $(IMAGE_REGISTRY)/$(OPERATOR_IMAGE):$(IMAGE_TAG) .
 
 container-build-registry:
@@ -78,10 +78,13 @@ container-push-operator:
 container-push-registry:
 	docker push $(IMAGE_REGISTRY)/$(REGISTRY_IMAGE):$(IMAGE_TAG)
 
+csv-generator: gen-operator-sdk
+	./build/make-csv-generator.sh
+
 gen-operator-sdk:
 	./hack/gen-operator-sdk.sh ${OPERATOR_SDK_VERSION}
 
-manifests: gen-operator-sdk
+manifests: csv-generator
 	./build/make-manifests.sh ${IMAGE_TAG}
 	./hack/release-manifests.sh ${IMAGE_TAG}
 
@@ -92,12 +95,12 @@ cluster-down:
 	./cluster/down.sh
 
 cluster-sync:
-	./cluster/sync.sh ${IMAGE_TAG}	
+	./cluster/sync.sh
 
 cluster-functest:
 	./cluster/functest.sh
 
 cluster-clean:
-	./cluster/clean.sh		
+	./cluster/clean.sh
 
 .PHONY: all check fmt test container-build container-push manifests cluster-up cluster-down cluster-sync cluster-functest cluster-clean

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -9,8 +9,16 @@ ENV ENTRYPOINT=/entrypoint \
     OPERATOR=/node-maintenance-operator \
     USER_UID=1001 \
     USER_NAME=node-maintenance-operator
+
+LABEL org.kubevirt.hco.csv-generator.v1="/usr/bin/csv-generator"
+
 COPY --from=builder /go/src/kubevirt.io/node-maintenance-operator/build/bin/user_setup /user_setup
 RUN /user_setup
+
+COPY deploy/crds /deploy/crds
+COPY manifests/generated /manifests/generated
+COPY build/csv-generator.sh /usr/bin/csv-generator
+
 COPY --from=builder /node-maintenance-operator ${OPERATOR}
 COPY --from=builder /go/src/kubevirt.io/node-maintenance-operator/build/bin/entrypoint ${ENTRYPOINT}
 ENTRYPOINT ${ENTRYPOINT}

--- a/build/Dockerfile.registry
+++ b/build/Dockerfile.registry
@@ -3,7 +3,8 @@ FROM quay.io/openshift/origin-operator-registry
 COPY manifests /registry
 
 # Initialize the database
-RUN initializer --manifests /registry --output bundles.db
+RUN rm -rf /registry/generated && \
+    initializer --manifests /registry --output bundles.db
 
 # There are multiple binaries in the origin-operator-registry
 # We want the registry-server

--- a/build/csv-generator.sh
+++ b/build/csv-generator.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+set -e
+
+MANIFESTS_GENERATED_DIR="manifests/generated"
+CRDS_DIR="deploy/crds"
+if ! [ -d $MANIFESTS_GENERATED_DIR ]; then
+    MANIFESTS_GENERATED_DIR="/manifests/generated"
+    CRDS_DIR="/deploy/crds"
+fi
+MANIFESTS_GENERATED_CSV=${MANIFESTS_GENERATED_DIR}/node-maintenance-operator.vVERSION.clusterserviceversion.yaml
+TMP_FILE=$(mktemp)
+
+replace_env_var() {
+    local value_offset="                  "
+    local key=$1
+    local var=$2
+    sed -i "s/- name: ${key}/- name: $1\n${value_offset}value: \"${var}\"/g" ${TMP_FILE}
+}
+
+help_text() {
+    echo "USAGE: csv-generator --csv-version=<version> --namespace=<namespace> --operator-image=<operator image> [optional args]"
+    echo ""
+    echo "ARGS:"
+    echo "  --csv-version:    (REQUIRED) The version of the CSV file"
+    echo "  --namespace:      (REQUIRED) The namespace set on the CSV file"
+    echo "  --operator-image: (REQUIRED) The operator container image to use in the CSV file"
+    echo "  --watch-namespace:   (OPTIONAL)"
+    echo "  --dump-crds:         (OPTIONAL) Dumps CRD manifests with the CSV to stdout"
+}
+
+# REQUIRED ARGS
+CSV_VERSION=""
+NAMESPACE=""
+OPERATOR_IMAGE=""
+
+# OPTIONAL ARGS
+WATCH_NAMESPACE=""
+
+while (( "$#" )); do
+    ARG=`echo $1 | awk -F= '{print $1}'`
+    VAL=`echo $1 | awk -F= '{print $2}'`
+    shift
+
+    case "$ARG" in
+    --csv-version)
+        CSV_VERSION=$VAL
+        ;;
+    --namespace)
+        NAMESPACE=$VAL
+        ;;
+    --operator-image)
+        OPERATOR_IMAGE=$VAL
+        ;;
+    --watch-namespace)
+        WATCH_NAMESPACE=$VAL
+        ;;
+    --dump-crds)
+        DUMP_CRDS="true"
+        ;;
+    --)
+        break
+        ;;
+    *) # unsupported flag
+        echo "Error: Unsupported flag $ARG" >&2
+        exit 1
+        ;;
+    esac
+done
+
+if [ -z "$CSV_VERSION" ] || [ -z "$NAMESPACE" ] || [ -z "$OPERATOR_IMAGE" ]; then
+    echo "Error: Missing required arguments"
+    help_text
+    exit 1
+fi
+
+cp ${MANIFESTS_GENERATED_CSV} ${TMP_FILE}
+
+# replace placeholder version with a human readable variable name
+# that will be used later on by csv-generator
+sed -i "s/PLACEHOLDER_CSV_VERSION/${CSV_VERSION}/g" ${TMP_FILE}
+sed -i "s/namespace: node-maintenance-operator/namespace: ${NAMESPACE}/g" ${TMP_FILE}
+sed -i "s|quay.io/kubevirt/node-maintenance-operator:<IMAGE_VERSION>|${OPERATOR_IMAGE}|g" ${TMP_FILE}
+
+replace_env_var "WATCH_NAMESPACE" $WATCH_NAMESPACE
+
+# dump CSV and CRD manifests to stdout
+echo "---"
+cat ${TMP_FILE}
+rm ${TMP_FILE}
+if [ "$DUMP_CRDS" = "true" ]; then
+    for CRD in $( ls ${CRDS_DIR}/nodemaintenance_*crd.yaml ); do
+        echo "---"
+        cat ${CRD}
+    done
+fi

--- a/build/make-csv-generator.sh
+++ b/build/make-csv-generator.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -e
+
+SELF=$( realpath $0 )
+BASEPATH=$( dirname $SELF )
+
+if [ -x "${BASEPATH}/../operator-sdk" ]; then
+       OPERATOR_SDK="${BASEPATH}/../operator-sdk"
+else
+    which operator-sdk &> /dev/null || {
+        echo "operator-sdk not found (see https://github.com/operator-framework/operator-sdk)"
+        exit 1
+    }
+    OPERATOR_SDK="operator-sdk"
+fi
+
+MANIFESTS_GENERATED_DIR="manifests/generated"
+MANIFESTS_GENERATED_CSV=${MANIFESTS_GENERATED_DIR}/node-maintenance-operator.vVERSION.clusterserviceversion.yaml
+PLACEHOLDER_CSV_VERSION="9999.9999.9999"
+
+# Create CSV with placeholder version. The version
+# has to be semver compatible in order for the
+# operator sdk to create it for us. That's why we
+# are using the absurd 9999.9999.9999 version here.
+${OPERATOR_SDK} olm-catalog gen-csv --csv-version ${PLACEHOLDER_CSV_VERSION}
+
+# Move CSV to generated folder
+mv deploy/olm-catalog/node-maintenance-operator/${PLACEHOLDER_CSV_VERSION}/node-maintenance-operator.v${PLACEHOLDER_CSV_VERSION}.clusterserviceversion.yaml $MANIFESTS_GENERATED_CSV
+
+# cleanup placeholder version's deployment dir
+rm -rf mv deploy/olm-catalog/node-maintenance-operator/${PLACEHOLDER_CSV_VERSION}
+
+# replace placeholder version with a human readable variable name
+# that will be used later on by csv-generator
+sed -i "s/${PLACEHOLDER_CSV_VERSION}/PLACEHOLDER_CSV_VERSION/g" $MANIFESTS_GENERATED_CSV
+
+# inject the CRD and Description related data into the CSV
+cp $MANIFESTS_GENERATED_CSV ${MANIFESTS_GENERATED_CSV}.tmp
+python3 build/update-olm.py ${MANIFESTS_GENERATED_CSV}.tmp > ${MANIFESTS_GENERATED_CSV}
+rm ${MANIFESTS_GENERATED_CSV}.tmp

--- a/build/make-manifests.sh
+++ b/build/make-manifests.sh
@@ -18,36 +18,14 @@ BUNDLE_DIR="${2:-manifests/node-maintenance-operator}"
 BUNDLE_DIR_VERSION="${BUNDLE_DIR}/${TAG}"
 CHANNEL="beta"
 
-if [ -x "${BASEPATH}/../operator-sdk" ]; then
-       OPERATOR_SDK="${BASEPATH}/../operator-sdk"
-else
-	which operator-sdk &> /dev/null || {
-		echo "operator-sdk not found (see https://github.com/operator-framework/operator-sdk)"
-		exit 1
-	}
-	OPERATOR_SDK="operator-sdk"
-fi
-
 HAVE_COURIER=0
 if which operator-courier &> /dev/null; then
 	HAVE_COURIER=1
 fi
 
-# store original operator.yaml file
-cp deploy/operator.yaml operator.yaml
-sed -i "s/<IMAGE_VERSION>/${TAG}/g" deploy/operator.yaml
-
 mkdir -p ${BUNDLE_DIR_VERSION}
 
-# note: this creates under deploy/olm-catalog ...
-${OPERATOR_SDK} olm-catalog gen-csv --csv-version ${VERSION}
-
-# move back original operator.yaml file
-mv operator.yaml deploy/operator.yaml
-
-python3 build/update-olm.py \
-	deploy/olm-catalog/node-maintenance-operator/${VERSION}/node-maintenance-operator.${TAG}.clusterserviceversion.yaml > \
-	${BUNDLE_DIR_VERSION}/node-maintenance-operator.${TAG}.clusterserviceversion.yaml
+./build/csv-generator.sh --csv-version=${VERSION} --namespace=placeholder --operator-image="quay.io/kubevirt/node-maintenance-operator:${TAG}" > ${BUNDLE_DIR_VERSION}/node-maintenance-operator.${TAG}.clusterserviceversion.yaml
 
 # caution: operator-courier (as in 5a4852c) wants *one* entity per yaml file (e.g. it does NOT use safe_load_all)
 for CRD in $( ls deploy/crds/nodemaintenance_*crd.yaml ); do

--- a/manifests/generated/node-maintenance-operator.vVERSION.clusterserviceversion.yaml
+++ b/manifests/generated/node-maintenance-operator.vVERSION.clusterserviceversion.yaml
@@ -1,0 +1,173 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: '[{"apiVersion":"kubevirt.io/v1alpha1","kind":"NodeMaintenance","metadata":{"name":"nodemaintenance-xyz"},"spec":{"nodeName":"node02","reason":"Test
+      node maintenance"}}]'
+    capabilities: Basic Install
+    categories: OpenShift Optional
+    containerImage: quay.io/kubevirt/node-maintenance-operator
+    description: Node-maintenance-operator maintains nodes in cluster
+    repository: https://github.com/kubevirt/node-maintenance-operator
+  name: node-maintenance-operator.vPLACEHOLDER_CSV_VERSION
+  namespace: node-maintenance-operator
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: Represents a deployment of node maintenance crd
+      displayName: KubeVirt node maintenance
+      kind: NodeMaintenance
+      name: nodemaintenances.kubevirt.io
+      specDescriptors:
+      - description: The version of the node maintenance to deploy
+        displayName: Version
+        path: version
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.node-maintenance:version
+      version: v1alpha1
+  description: Node maintenance operator
+  displayName: Node Maintenance Operator
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - ''
+          resources:
+          - services
+          - endpoints
+          - events
+          - configmaps
+          - serviceaccounts
+          verbs:
+          - '*'
+        - apiGroups:
+          - ''
+          resources:
+          - nodes
+          verbs:
+          - get
+          - list
+          - update
+          - patch
+          - watch
+        - apiGroups:
+          - ''
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ''
+          resources:
+          - pods/eviction
+          verbs:
+          - create
+        - apiGroups:
+          - ''
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - oauth.openshift.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        serviceAccountName: node-maintenance-operator
+      deployments:
+      - name: node-maintenance-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: node-maintenance-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: node-maintenance-operator
+            spec:
+              affinity:
+                nodeAffinity:
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    nodeSelectorTerms:
+                    - matchExpressions:
+                      - key: node-role.kubernetes.io/master
+                        operator: Exists
+              containers:
+              - env:
+                - name: WATCH_NAMESPACE
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: node-maintenance-operator
+                image: quay.io/kubevirt/node-maintenance-operator:<IMAGE_VERSION>
+                imagePullPolicy: Always
+                name: node-maintenance-operator
+                resources: {}
+              serviceAccountName: node-maintenance-operator
+              tolerations:
+              - effect: NoSchedule
+                key: node-role.kubernetes.io/master
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - KubeVirt
+  - Virtualization
+  - Node-maintenance
+  labels:
+    alm-owner-kubevirt: nodemaintenanceoperator
+    operated-by: nodemaintenanceoperator
+  links:
+  - name: KubeVirt
+    url: https://kubevirt.io
+  - name: Source Code
+    url: https://github.com/kubevirt/node-maintenance-operator
+  maintainers:
+  - email: kubevirt-dev@googlegroups.com
+    name: KubeVirt project
+  maturity: alpha
+  provider:
+    name: KubeVirt project
+  selector:
+    matchLabels:
+      alm-owner-kubevirt: nodemaintenanceoperator
+      operated-by: nodemaintenanceoperator
+  version: PLACEHOLDER_CSV_VERSION


### PR DESCRIPTION
This PR adds the HCO's csv-generator logic to the nmo's container image and follows the same pattern found [here](https://github.com/MarSik/kubevirt-ssp-operator/pull/66) for the ssp operator. 

## Overview of Changes
New make csv-generator make target generates a reusable pre-generated CSV file with placeholder values in the manifests/generated dir.
make container-build-operator copies in both the placeholder CSV file and the new csv-generator script
The operator's container can now be used to generate a corresponding CSV file using the csv-generator entry-point.

**Basic Example**
```
docker run -it -rm --entrypoint=/usr/bin/csv-generator <operator image> --csv-version=1.1.1 --operator-image=someregistry/nmo-opereator:sometag --namespace=placeholder
```

The HCO will be using this csv-generator entrypoint in the process of creating the aggregated HCO CSV that encompasses multiple component-level operators (like nmo).

