### PR TITLE
Add pod statistics to status

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,9 @@ status:
   phase: "Running"
   lastError: "Last failure message"
   pendingPods: [pod-A,pod-B,pod-C]
+  totalPods: 5
+  evictionPods: 3
+
 ```
 
 `phase` is the representation of the maintenance progress and can hold a string value of: Running|Succeeded.
@@ -227,7 +230,11 @@ The phase is updated for each processing attempt on the CR.
 
 `lastError` represents the latest error if any for the latest reconciliation.
 
-`pendingPods` is an array of pods that failed to be evicted in the latest reconciliation.
+`pendingPods` PendingPods is a list of pending pods for eviction.
+
+`totalPods` is the total number of all pods on the node from the start.
+
+`evictionPods` is the total number of pods up for eviction from the start.
 
 ## Tests
 

--- a/deploy/crds/nodemaintenance_crd.yaml
+++ b/deploy/crds/nodemaintenance_crd.yaml
@@ -40,20 +40,29 @@ spec:
           type: object
         status:
           properties:
+            evictionPods:
+              description: EvictionPods is the total number of pods up for eviction
+                from the start
+              format: int64
+              type: integer
             lastError:
               description: LastError represents the latest error if any in the latest
                 reconciliation
               type: string
             pendingPods:
-              description: PendingPods are pods that failed to be evicted in the latest
-                reconciliation
+              description: PendingPods is a list of pending pods for eviction
               items:
-                type: object
+                type: string
               type: array
             phase:
               description: Phase is the represtation of the maintenanace progress
                 (Running,Succeeded)
               type: string
+            totalpods:
+              description: TotalPods is the total number of all pods on the node from
+                the start
+              format: int64
+              type: integer
           type: object
   version: v1alpha1
   versions:

--- a/pkg/apis/kubevirt/v1alpha1/nodemaintenance_types.go
+++ b/pkg/apis/kubevirt/v1alpha1/nodemaintenance_types.go
@@ -1,7 +1,6 @@
 package v1alpha1
 
 import (
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -56,8 +55,12 @@ type NodeMaintenanceStatus struct {
 	Phase MaintenancePhase `json:"phase,omitempty"`
 	// LastError represents the latest error if any in the latest reconciliation
 	LastError string `json:"lastError,omitempty"`
-	// PendingPods are pods that failed to be evicted in the latest reconciliation
-	PendingPods []corev1.Pod `json:"pendingPods,omitempty"`
+	// PendingPods is a list of pending pods for eviction
+	PendingPods []string `json:"pendingPods,omitempty"`
+	// TotalPods is the total number of all pods on the node from the start
+	TotalPods int `json:"totalpods,omitempty"`
+	// EvictionPods is the total number of pods up for eviction from the start
+	EvictionPods int `json:"evictionPods,omitempty"`
 }
 
 func init() {

--- a/pkg/apis/kubevirt/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/kubevirt/v1alpha1/zz_generated.deepcopy.go
@@ -5,7 +5,6 @@
 package v1alpha1
 
 import (
-	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -91,10 +90,8 @@ func (in *NodeMaintenanceStatus) DeepCopyInto(out *NodeMaintenanceStatus) {
 	*out = *in
 	if in.PendingPods != nil {
 		in, out := &in.PendingPods, &out.PendingPods
-		*out = make([]v1.Pod, len(*in))
-		for i := range *in {
-			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 	return
 }

--- a/pkg/controller/nodemaintenance/nodemaintenance_controller.go
+++ b/pkg/controller/nodemaintenance/nodemaintenance_controller.go
@@ -185,8 +185,7 @@ func (r *ReconcileNodeMaintenance) Reconcile(request reconcile.Request) (reconci
 		return reconcile.Result{}, nil
 	}
 
-	instance.Status.Phase = kubevirtv1alpha1.MaintenanceRunning
-	err = r.client.Status().Update(context.TODO(), instance)
+	err = r.initMaintenanceStatus(instance)
 	if err != nil {
 		reqLogger.Error(err, "Failed to update NodeMaintenance with \"Running\" status")
 		return r.reconcileAndError(instance, err)
@@ -280,13 +279,40 @@ func (r *ReconcileNodeMaintenance) StartPodInformer(node *corev1.Node, stop <-ch
 	return nil
 }
 
+func (r *ReconcileNodeMaintenance) initMaintenanceStatus(nm *kubevirtv1alpha1.NodeMaintenance) error {
+	if nm.Status.Phase == "" {
+		nm.Status.Phase = kubevirtv1alpha1.MaintenanceRunning
+		pendingList, errlist := r.drainer.GetPodsForDeletion(nm.Spec.NodeName)
+		if errlist != nil {
+			return fmt.Errorf("Failed to get pods for eviction while initializing status")
+		}
+		if pendingList != nil {
+			nm.Status.PendingPods = GetPodNameList(pendingList.Pods())
+		}
+		nm.Status.EvictionPods = len(nm.Status.PendingPods)
+
+		podlist := &corev1.PodList{}
+		listOps := &client.ListOptions{
+			FieldSelector: fields.SelectorFromSet(fields.Set{"spec.nodeName": nm.Spec.NodeName}),
+		}
+		err := r.client.List(context.TODO(), listOps, podlist)
+		if err != nil {
+			return err
+		}
+		nm.Status.TotalPods = len(podlist.Items)
+		err = r.client.Status().Update(context.TODO(), nm)
+		return err
+	}
+	return nil
+}
+
 func (r *ReconcileNodeMaintenance) reconcileAndError(nm *kubevirtv1alpha1.NodeMaintenance, err error) (reconcile.Result, error) {
 	nm.Status.LastError = err.Error()
 
 	if nm.Spec.NodeName != "" {
 		pendingList, _ := r.drainer.GetPodsForDeletion(nm.Spec.NodeName)
 		if pendingList != nil {
-			nm.Status.PendingPods = pendingList.Pods()
+			nm.Status.PendingPods = GetPodNameList(pendingList.Pods())
 		}
 	}
 

--- a/pkg/controller/nodemaintenance/utils.go
+++ b/pkg/controller/nodemaintenance/utils.go
@@ -1,5 +1,7 @@
 package nodemaintenance
 
+import corev1 "k8s.io/api/core/v1"
+
 // ContainsString checks if the string array contains the given string.
 func ContainsString(slice []string, s string) bool {
 	for _, item := range slice {
@@ -18,5 +20,13 @@ func RemoveString(slice []string, s string) (result []string) {
 		}
 		result = append(result, item)
 	}
-	return
+	return result
+}
+
+// GetPodNameList returns a list of pod names from a pod list
+func GetPodNameList(pods []corev1.Pod) (result []string) {
+	for _, pod := range pods {
+		result = append(result, pod.ObjectMeta.Name)
+	}
+	return result
 }

--- a/test/e2e/nodemaintenance_test.go
+++ b/test/e2e/nodemaintenance_test.go
@@ -349,7 +349,7 @@ func checkFailureStatus(t *testing.T, f *framework.Framework) {
 		if err != nil {
 			t.Logf("Failed to get deployment pods")
 		}
-		if pods.Items[0].Name != nm.Status.PendingPods[0].Name {
+		if pods.Items[0].Name != nm.Status.PendingPods[0] {
 			t.Logf("Status.PendingPods on %s nodeMaintenance does not contain pod %s", nm.Name, pods.Items[0].Name)
 		}
 	}


### PR DESCRIPTION
Updated Node maitenance CR status to contain the following:

`pendingPods` PendingPods is a list of pending pods for eviction. - fixed to hold pods names (instead of pod objects) 

`totalPods` is the total number of all pods on the node from the start.

`evictionPods` is the total number of pods up for eviction from the start.