### PR TITLE
Prevent NMO from being deployed on master nodes

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -20,10 +20,7 @@ spec:
             nodeSelectorTerms:
             - matchExpressions:
               - key: node-role.kubernetes.io/master
-                operator: Exists
-      tolerations:
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
+                operator: DoesNotExist
       containers:
         - name: node-maintenance-operator
           # Replace this with the built image name

--- a/test/e2e/nodemaintenance_test.go
+++ b/test/e2e/nodemaintenance_test.go
@@ -477,13 +477,3 @@ func getTestDeploymentHostnames(t *testing.T, f *framework.Framework) []string {
 
 	return hostnames
 }
-
-func sliceContainsString(slice []string, str string) bool {
-	for _, s := range slice {
-		if s == str {
-			return true
-		}
-	}
-
-	return false
-}

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -1,0 +1,11 @@
+package e2e
+
+func sliceContainsString(slice []string, str string) bool {
+	for _, s := range slice {
+		if s == str {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
This PR proposes to prevent NMO pods from being deployed on master nodes, as it is a bad practice to deploy 3rd party apps on master nodes in OCP.