### PR TITLE
Update catalog namespace for OCP 4.2 and higher

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
   name: node-maintenance-operator
-  namespace: openshift-operator-lifecycle-manager
+  namespace: openshift-marketplace
 spec:
   sourceType: grpc
   image: quay.io/kubevirt/node-maintenance-operator-registry:<VERSION>
@@ -100,7 +100,7 @@ spec:
   channel: beta
   name: node-maintenance-operator
   source: node-maintenance-operator
-  sourceNamespace: openshift-operator-lifecycle-manager
+  sourceNamespace: openshift-marketplace
   startingCSV: node-maintenance-operator.<VERSION>
 EOF
 ```

--- a/olm-deploy-manifests/nm-catalog-source.yaml
+++ b/olm-deploy-manifests/nm-catalog-source.yaml
@@ -2,7 +2,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
   name: node-maintenance-operator
-  namespace: openshift-operator-lifecycle-manager
+  namespace: openshift-marketplace
 spec:
   sourceType: grpc
   image: quay.io/kubevirt/node-maintenance-operator-registry:v0.3.0

--- a/olm-deploy-manifests/nm-sub.yaml
+++ b/olm-deploy-manifests/nm-sub.yaml
@@ -7,5 +7,5 @@ spec:
   channel: beta
   name: node-maintenance-operator
   source: node-maintenance-operator
-  sourceNamespace: openshift-operator-lifecycle-manager
+  sourceNamespace: openshift-marketplace
   startingCSV: node-maintenance-operator.v0.3.0


### PR DESCRIPTION
Starting with OCP 4.2, the namespace for global catalogs has
been changed to openshift-marketplace.

Signed-off-by: Richard Su <rwsu@redhat.com>