### PR TITLE
fix openapi validation error for CRD of node maintenance operator

### DIFF
--- a/deploy/crds/nodemaintenance_crd.yaml
+++ b/deploy/crds/nodemaintenance_crd.yaml
@@ -64,6 +64,7 @@ spec:
               format: int64
               type: integer
           type: object
+      type: object
   version: v1beta1
   versions:
   - name: v1beta1

--- a/hack/functest.sh
+++ b/hack/functest.sh
@@ -15,7 +15,7 @@ if [ -z "$KUBEVIRTCI_CONFIG_PATH" ]; then
     )"
 fi
 
-
+KUBECTL_CMD="${KUBEVIRTCI_PATH}/kubectl.sh"
 
 function new_test() {
     name=$1
@@ -42,4 +42,31 @@ KUBE_CONFIG=$(${KUBEVIRTCI_PATH}/kubeconfig.sh)
 TEST_NAMESPACE=node-maintenance-operator go test ./test/e2e/... -root=$(pwd) -kubeconfig=${KUBE_CONFIG} -globalMan _out/nodemaintenance_crd.yaml --namespacedMan _out/namespace-init.yaml -singleNamespace
 
 echo "E2e tests passed"
+
+echo "check validation of openaAPIV3Schema"
+
+$KUBECTL_CMD create -f _out/namespace-init.yaml
+
+$KUBECTL_CMD create -f _out/nodemaintenance_crd.yaml
+
+echo "validate CRD"
+
+VALIDATE_CRD=$($KUBECTL_CMD get -o yaml crd nodemaintenances.kubevirt.io)
+if [[ $VALIDATE_CRD == "" ]]; then
+	echo "can't validate CRD, check if deployment is running"
+	exit 1
+fi
+
+set +e
+VALIDATION_ERRORS=$(echo "$VALIDATE_CRD" | grep -c "spec.validation.openAPIV3Schema")
+set -e
+
+if [[ $VALIDATION_ERRORS != "0" ]]; then
+	echo "validation of CRD failed"
+	exit 1
+fi
+
+echo "check validation of openaAPIV3Schema passed"
+
+
 

--- a/hack/functest.sh
+++ b/hack/functest.sh
@@ -15,6 +15,7 @@ if [ -z "$KUBEVIRTCI_CONFIG_PATH" ]; then
     )"
 fi
 
+
 KUBECTL_CMD="${KUBEVIRTCI_PATH}/kubectl.sh"
 
 function new_test() {
@@ -71,7 +72,7 @@ VALIDATION_ERRORS=$(echo "$VALIDATE_CRD" | grep -c "spec.validation.openAPIV3Sch
 if [[ $VALIDATION_ERRORS != "0" ]]; then
 	echo "validation of CRD failed"
 	echo "Validation errors:"
-	echo "$VALIDATE_CRD" | grep "spec.validation.openAPIV3Schema"
+	echo "$VALIDATION_ERRORS"
 	exit 1
 fi
 

--- a/hack/functest.sh
+++ b/hack/functest.sh
@@ -60,7 +60,7 @@ $KUBECTL_CMD create -f _out/nodemaintenance_crd.yaml
 
 echo "validate CRD"
 
-VALIDATE_CRD=$($KUBECTL_CMD get -o yaml crd nodemaintenances.kubevirt.io || true)
+VALIDATE_CRD=$($KUBECTL_CMD get -o yaml crd nodemaintenances.nodemaintenance.kubevirt.io || true)
 if [[ $VALIDATE_CRD == "" ]]; then
 	echo "can't validate CRD, check if the CRD is installed"
 	exit 1

--- a/hack/functest.sh
+++ b/hack/functest.sh
@@ -62,7 +62,7 @@ echo "validate CRD"
 
 VALIDATE_CRD=$($KUBECTL_CMD get -o yaml crd nodemaintenances.kubevirt.io || true)
 if [[ $VALIDATE_CRD == "" ]]; then
-	echo "can't validate CRD, check if deployment is running"
+	echo "can't validate CRD, check if the CRD is installed"
 	exit 1
 fi
 

--- a/hack/functest.sh
+++ b/hack/functest.sh
@@ -76,6 +76,3 @@ if [[ $VALIDATION_ERRORS != "0" ]]; then
 fi
 
 echo "check validation of openaAPIV3Schema passed"
-
-
-

--- a/test/e2e/nodemaintenance_test.go
+++ b/test/e2e/nodemaintenance_test.go
@@ -2,12 +2,10 @@ package e2e
 
 import (
 	goctx "context"
-	"os/exec"
 	"fmt"
 	"reflect"
 	"testing"
 	"time"
-	"strings"
 
 	apis "kubevirt.io/node-maintenance-operator/pkg/apis"
 	operator "kubevirt.io/node-maintenance-operator/pkg/apis/kubevirt/v1alpha1"
@@ -75,28 +73,6 @@ func showDeploymentStatus(t *testing.T, f *framework.Framework) {
 	}
 	str := buf.String()
 	t.Fatalf("operator logs: %s", str)
-}
-
-const (
-	scriptShowCRD = `./kubevirtci/cluster-up/kubectl.sh get -o yaml crd nodemaintenances.kubevirt.io`
-)
-
-// check operator crd for opeAPIV3Schema validation errors.
-func checkOperatorCRD(t *testing.T) {
-	clicmd := exec.Command("bash", "-xc", scriptShowCRD)
-	output, err := clicmd.CombinedOutput()
-
-	if err != nil || output == nil {
-		if output != nil {
-			t.Fatalf("can't get CRD. status: %v output %s\n", err, output)
-		}  else {
-			t.Fatalf("can't get CRD. status: %v\n", err)
-		}
-	}
-
-	if sout := string(output); strings.Contains(sout, "spec.validation.openAPIV3Schema") {
-		t.Fatalf("operator CRD failed validation: %s", output);
-	}
 }
 
 func TestNodeMainenance(t *testing.T) {
@@ -307,7 +283,6 @@ func nodeMaintenanceTest(t *testing.T, f *framework.Framework, ctx *framework.Te
 		t.Fatal(err)
 	}
 
-	checkOperatorCRD(t)
 	return nil
 }
 


### PR DESCRIPTION
fix an error while validating the openapi schema. 
The last two commits of the PR are a check for openAPI validation errors in the e2e tests, and the fix of the CRD
This PR is created from #68 by cherry picking its changes of top of the new master branch.