### PR TITLE
Add coverage report to build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ IMAGE_REGISTRY ?= quay.io/kubevirt
 IMAGE_TAG ?= latest
 OPERATOR_IMAGE ?= node-maintenance-operator
 REGISTRY_IMAGE ?= node-maintenance-operator-registry
+TARGETCOVERAGE=60
 
 KUBEVIRTCI_PATH=$$(pwd)/kubevirtci/cluster-up
 KUBEVIRTCI_CONFIG_PATH=$$(pwd)/_ci-configs
@@ -56,7 +57,7 @@ goimports-check: $(cmd_sources) $(pkg_sources)
 	go run ./vendor/golang.org/x/tools/cmd/goimports -d ./pkg ./cmd
 
 test: $(GINKGO)
-	./hack/coverage.sh $(GINKGO)
+	./hack/coverage.sh $(GINKGO) $(TARGETCOVERAGE)
 
 gen-k8s: $(apis_sources)
 	./hack/gen-k8s.sh generate k8s

--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,6 @@ TARGETS = \
 	manifests \
 	test
 
-COVERAGE_FILE := cover.out
-GINKGO_EXTRA_ARGS ?=
-GINKGO_ARGS ?= -v -r --progress $(GINKGO_EXTRA_ARGS) -cover -coverprofile=$(COVERAGE_FILE) -outputdir=. --skipPackage ./vendor
 GINKGO ?= build/_output/bin/ginkgo
 
 $(GINKGO): Gopkg.toml
@@ -59,9 +56,7 @@ goimports-check: $(cmd_sources) $(pkg_sources)
 	go run ./vendor/golang.org/x/tools/cmd/goimports -d ./pkg ./cmd
 
 test: $(GINKGO)
-	find . -name $(COVERAGE_FILE) | xargs rm -f
-	$(GINKGO) $(GINKGO_ARGS) ./pkg/ ./cmd/
-	./hack/coverage.sh $(COVERAGE_FILE)
+	./hack/coverage.sh $(GINKGO)
 
 gen-k8s: $(apis_sources)
 	./hack/gen-k8s.sh generate k8s

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,9 @@ TARGETS = \
 	manifests \
 	test
 
+COVERAGE_FILE := cover.out
 GINKGO_EXTRA_ARGS ?=
-GINKGO_ARGS ?= --v -r --progress $(GINKGO_EXTRA_ARGS)
+GINKGO_ARGS ?= -v -r --progress $(GINKGO_EXTRA_ARGS) -cover -coverprofile=$(COVERAGE_FILE) -outputdir=. --skipPackage ./vendor
 GINKGO ?= build/_output/bin/ginkgo
 
 $(GINKGO): Gopkg.toml
@@ -58,7 +59,9 @@ goimports-check: $(cmd_sources) $(pkg_sources)
 	go run ./vendor/golang.org/x/tools/cmd/goimports -d ./pkg ./cmd
 
 test: $(GINKGO)
+	find . -name $(COVERAGE_FILE) | xargs rm -f
 	$(GINKGO) $(GINKGO_ARGS) ./pkg/ ./cmd/
+	./hack/coverage.sh $(COVERAGE_FILE)
 
 gen-k8s: $(apis_sources)
 	./hack/gen-k8s.sh generate k8s

--- a/hack/coverage.sh
+++ b/hack/coverage.sh
@@ -1,0 +1,35 @@
+#!/bin/bash -ex
+
+COVERAGE_FILE=$1
+
+declare -a EXCLUDE_FILES_FROM_COVERAGE=("nodemaintenance_controller_init.go")
+
+# ginkgo and html coverage don't quite live in harmony. fix that.
+# ginkgo aggregates the coverage file, but the resulting file is not accepted by go tool cover.
+# the reason is that there are repeated mode: headers, we need to leave just the first one of them
+sed -i  '/mode: atomic/d' $COVERAGE_FILE
+sed -i '1i mode: atomic' $COVERAGE_FILE
+
+function exclude_file {
+	local file=$2
+	local term=$1
+	set -x
+
+	grep -v $term ${file} >${file}.tmp
+	mv -f ${file}.tmp $file
+}
+
+# so that the function can be called from xargs
+export -f exclude_file
+
+# exclude files listed from coverage report
+for f in "${EXCLUDE_FILES_FROM_COVERAGE}"; do
+	find . -name $COVERAGE_FILE | xargs bash -c "exclude_file $f $@"
+done
+
+# function coverage report (textual)
+go tool cover -func=$COVERAGE_FILE
+
+# html coverage report
+go tool cover -html=$COVERAGE_FILE
+

--- a/hack/coverage.sh
+++ b/hack/coverage.sh
@@ -39,7 +39,7 @@ function exclude_file {
 # so that the function can be called from xargs
 export -f exclude_file
 
-# exclude files listed from coverage report
+# exclude files listed as excluded from coverage report
 for f in "${EXCLUDE_FILES_FROM_COVERAGE}"; do
 	find . -name $COVERAGE_FILE | xargs bash -c "exclude_file $f $@"
 done
@@ -47,6 +47,6 @@ done
 # function coverage report (textual)
 go tool cover -func=$COVERAGE_FILE
 
-# html coverage report
+# html coverage report (this makes sense if run in interactive mode - go tool displays the results in the current browser)
 go tool cover -html=$COVERAGE_FILE
 

--- a/pkg/controller/nodemaintenance/nodemaintenance_controller.go
+++ b/pkg/controller/nodemaintenance/nodemaintenance_controller.go
@@ -21,58 +21,9 @@ import (
 	"k8s.io/kubectl/pkg/drain"
 	kubevirtv1alpha1 "kubevirt.io/node-maintenance-operator/pkg/apis/kubevirt/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-// Add creates a new NodeMaintenance Controller and adds it to the Manager. The Manager will set fields on the Controller
-// and Start it when the Manager is Started.
-func Add(mgr manager.Manager) error {
-	r, err := newReconciler(mgr)
-	if err != nil {
-		return err
-	}
-	return add(mgr, r)
-}
-
-// newReconciler returns a new reconcile.Reconciler
-func newReconciler(mgr manager.Manager) (reconcile.Reconciler, error) {
-	r := &ReconcileNodeMaintenance{client: mgr.GetClient(), scheme: mgr.GetScheme()}
-	err := initDrainer(r, mgr.GetConfig())
-	Handler = r
-	return r, err
-}
-
-// add adds a new Controller to mgr with r as the reconcile.Reconciler
-func add(mgr manager.Manager, r reconcile.Reconciler) error {
-	// Create a new controller
-	c, err := controller.New("nodemaintenance-controller", mgr, controller.Options{Reconciler: r})
-	if err != nil {
-		return err
-	}
-
-	pred := predicate.Funcs{
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			newObj := e.ObjectNew.(*kubevirtv1alpha1.NodeMaintenance)
-			return !newObj.DeletionTimestamp.IsZero()
-		},
-	}
-
-	// Create a source for watching noe maintenance events.
-	src := &source.Kind{Type: &kubevirtv1alpha1.NodeMaintenance{}}
-
-	// Watch for changes to primary resource NodeMaintenance
-	err = c.Watch(src, &handler.EnqueueRequestForObject{}, pred)
-	if err != nil {
-		return err
-	}
-	return nil
-}
 
 // writer implements io.Writer interface as a pass-through for klog.
 type writer struct {

--- a/pkg/controller/nodemaintenance/nodemaintenance_controller_init.go
+++ b/pkg/controller/nodemaintenance/nodemaintenance_controller_init.go
@@ -1,0 +1,60 @@
+//go:generate mockgen -source $GOFILE -package=$GOPACKAGE -destination=generated_mock_$GOFILE
+
+package nodemaintenance
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+	kubevirtv1alpha1 "kubevirt.io/node-maintenance-operator/pkg/apis/kubevirt/v1alpha1"
+)
+
+// Add creates a new NodeMaintenance Controller and adds it to the Manager. The Manager will set fields on the Controller
+// and Start it when the Manager is Started.
+func Add(mgr manager.Manager) error {
+	r, err := newReconciler(mgr)
+	if err != nil {
+		return err
+	}
+	return add(mgr, r)
+}
+
+// newReconciler returns a new reconcile.Reconciler
+func newReconciler(mgr manager.Manager) (reconcile.Reconciler, error) {
+	r := &ReconcileNodeMaintenance{client: mgr.GetClient(), scheme: mgr.GetScheme()}
+	err := initDrainer(r, mgr.GetConfig())
+	Handler = r
+	return r, err
+}
+
+// add adds a new Controller to mgr with r as the reconcile.Reconciler
+func add(mgr manager.Manager, r reconcile.Reconciler) error {
+	// Create a new controller
+	c, err := controller.New("nodemaintenance-controller", mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	pred := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			newObj := e.ObjectNew.(*kubevirtv1alpha1.NodeMaintenance)
+			return !newObj.DeletionTimestamp.IsZero()
+		},
+	}
+
+	// Create a source for watching noe maintenance events.
+	src := &source.Kind{Type: &kubevirtv1alpha1.NodeMaintenance{}}
+
+	// Watch for changes to primary resource NodeMaintenance
+	err = c.Watch(src, &handler.EnqueueRequestForObject{}, pred)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+


### PR DESCRIPTION
    add generation of coverage report on unit tests to the build
    
    - run ginkgo with coverage flags
    - postedit resulting coverage report so that git tool cover can parse it
    - exclude files that are not supposed to be covered by coverage report.
    - display function coverage report (textual)
    - generage html coverage report (this is only useful if run in
      interactive mode, here the default browser is invoked and displays the
      html coverage report)
    
      The significant coverage number appears at the end of the function
      report.
    
    Signed-off-by: Michael Moser <mmoser@redhat.com>
