### PR TITLE
Disallow master nodes to be taken into maint. mode if that violates quorum size.

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -6,6 +6,16 @@ metadata:
   name: node-maintenance-operator
 rules:
 - apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+  - create
+- apiGroups:
   - ""
   resources:
   - services

--- a/manifests/generated/node-maintenance-operator.vVERSION.clusterserviceversion.yaml
+++ b/manifests/generated/node-maintenance-operator.vVERSION.clusterserviceversion.yaml
@@ -31,6 +31,16 @@ spec:
       clusterPermissions:
       - rules:
         - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - get
+          - list
+          - watch
+          - delete
+          - create
+        - apiGroups:
           - ''
           resources:
           - services

--- a/manifests/node-maintenance-operator/v0.6.0/node-maintenance-operator.v0.6.0.clusterserviceversion.yaml
+++ b/manifests/node-maintenance-operator/v0.6.0/node-maintenance-operator.v0.6.0.clusterserviceversion.yaml
@@ -32,6 +32,16 @@ spec:
       clusterPermissions:
       - rules:
         - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - get
+          - list
+          - watch
+          - delete
+          - create
+        - apiGroups:
           - ''
           resources:
           - services

--- a/pkg/controller/nodemaintenance/check_quorum_size_test.go
+++ b/pkg/controller/nodemaintenance/check_quorum_size_test.go
@@ -1,0 +1,180 @@
+package nodemaintenance
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	policy "k8s.io/api/policy/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	k8sfakeclient "k8s.io/client-go/kubernetes/fake"
+)
+
+func areErrorsEqual(err1, err2 error) bool {
+	return (err1 != nil && err2 != nil && err1.Error() == err2.Error()) ||
+		(err1 == nil && err2 == nil)
+}
+
+var _ = Describe("checkQuorumValidity", func() {
+	type TestCaseDefinition struct {
+		info            string
+		currentHealthy  int32
+		requiredHealthy int32
+		disruptedPods   map[string]metav1.Time
+		isValidQuorum   bool
+	}
+	It("check fallback option of quorum check", func() {
+		testCases := []TestCaseDefinition{
+			{
+				info:            "quorum broken",
+				currentHealthy:  2,
+				requiredHealthy: 3,
+				isValidQuorum:   false,
+			},
+			{
+
+				info:            "quorum valid",
+				currentHealthy:  3,
+				requiredHealthy: 2,
+				isValidQuorum:   true,
+			},
+			{
+				info:            "quorum not broken with dirsupted pods",
+				currentHealthy:  4,
+				requiredHealthy: 2,
+				disruptedPods: map[string]metav1.Time{
+					"disruptedPod": metav1.Time{},
+				},
+				isValidQuorum: true,
+			},
+			{
+				info:            "quorum broken with dirsupted pods",
+				currentHealthy:  4,
+				requiredHealthy: 4,
+				disruptedPods: map[string]metav1.Time{
+					"disruptedPod": metav1.Time{},
+				},
+				isValidQuorum: false,
+			},
+		}
+		for _, c := range testCases {
+			By("test:" + c.info)
+			Context(c.info, func() {
+
+				masterNode := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "masternode",
+						Labels: map[string]string{
+							MasterNodeLabel: "",
+						},
+					},
+					Spec: corev1.NodeSpec{},
+				}
+				objs := []runtime.Object{
+					&policy.PodDisruptionBudgetList{
+						Items: []policy.PodDisruptionBudget{
+							policy.PodDisruptionBudget{
+								ObjectMeta: metav1.ObjectMeta{
+									Namespace: OpenshiftMachineConfigNamespace,
+								},
+								Spec: policy.PodDisruptionBudgetSpec{
+									MinAvailable: &intstr.IntOrString{
+										Type:   intstr.Int,
+										IntVal: int32(c.requiredHealthy),
+									},
+								},
+								Status: policy.PodDisruptionBudgetStatus{
+									CurrentHealthy: c.currentHealthy,
+									DisruptedPods:  c.disruptedPods,
+								},
+							},
+						},
+					},
+					masterNode,
+				}
+				cs := k8sfakeclient.NewSimpleClientset(objs...)
+				isValidQuorum, isFallbackCheck, _ := checkValidQuorum(cs, masterNode)
+				Expect(isValidQuorum).To(Equal(c.isValidQuorum))
+				Expect(isFallbackCheck).To(Equal(false))
+
+			})
+		}
+	})
+})
+
+var _ = Describe("checkQuorumValidityFallback", func() {
+	type TestCaseDefinition struct {
+		info            string
+		currentHealthy  int32
+		requiredHealthy int32
+		disruptedPods   map[string]metav1.Time
+		isValidQuorum   bool
+	}
+	It("check fallback option of quorum check", func() {
+		testCases := []TestCaseDefinition{
+			{
+				info:            "quorum broken",
+				currentHealthy:  2,
+				requiredHealthy: 3,
+				isValidQuorum:   false,
+			},
+			{
+
+				info:            "quorum valid",
+				currentHealthy:  3,
+				requiredHealthy: 2,
+				isValidQuorum:   true,
+			},
+			{
+				info:            "quorum not broken with dirsupted pods",
+				currentHealthy:  4,
+				requiredHealthy: 2,
+				disruptedPods: map[string]metav1.Time{
+					"disruptedPod": metav1.Time{},
+				},
+				isValidQuorum: true,
+			},
+		}
+		for _, c := range testCases {
+			By("test:" + c.info)
+			Context(c.info, func() {
+
+				masterNode := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "masternode",
+						Labels: map[string]string{
+							MasterNodeLabel: "",
+						},
+					},
+					Spec: corev1.NodeSpec{},
+				}
+				objs := []runtime.Object{
+							&policy.PodDisruptionBudget{
+								ObjectMeta: metav1.ObjectMeta{
+									Name: "etcpdb",
+									Namespace: NodeMaintenanceOperatorNamespace,
+								},
+								Spec: policy.PodDisruptionBudgetSpec{
+									MinAvailable: &intstr.IntOrString{
+										Type:   intstr.Int,
+										IntVal: int32(c.requiredHealthy),
+									},
+								},
+								Status: policy.PodDisruptionBudgetStatus{
+									CurrentHealthy: c.currentHealthy,
+									DisruptedPods:  c.disruptedPods,
+								},
+							},
+							masterNode,
+				}
+				cs := k8sfakeclient.NewSimpleClientset(objs...)
+				isValidQuorum, isFallbackCheck, _ := checkValidQuorum(cs, masterNode)
+				Expect(isValidQuorum).To(Equal(c.isValidQuorum))
+				Expect(isFallbackCheck).To(Equal(true))
+
+			})
+		}
+	})
+})

--- a/pkg/controller/nodemaintenance/check_quorum_size_test.go
+++ b/pkg/controller/nodemaintenance/check_quorum_size_test.go
@@ -103,4 +103,3 @@ var _ = Describe("checkQuorumValidity", func() {
 	})
 })
 
-

--- a/pkg/controller/nodemaintenance/master_quorum_check.go
+++ b/pkg/controller/nodemaintenance/master_quorum_check.go
@@ -14,29 +14,29 @@ import (
 
 const OpenshiftMachineConfigNamespace = "openshift-machine-config-operator"
 
-func checkValidQuorum(client kubernetes.Interface, node *corev1.Node) (bool, bool, error) {
+func checkValidQuorum(client kubernetes.Interface, node *corev1.Node) (bool, error) {
 	if isMasterNode(client, node) {
-		validQuorum, fallbackPDB, err := checkValidQuorumPdb(client)
+		validQuorum, err := checkValidQuorumPdb(client)
 		if err != nil {
-			return false, false, err
+			return false, err
 		}
 		log.Infof("node %s is a master. quorum status: %t", node.Name, validQuorum)
-		return validQuorum, fallbackPDB, nil
+		return validQuorum, nil
 	} else {
 		log.Infof("node %s is not a master", node.Name)
 	}
-	return true, false, nil
+	return true, nil
 }
 
-func findMcoPDBForEtcd(client kubernetes.Interface) (*policy.PodDisruptionBudget,bool,error) {
+func findMcoPDBForEtcd(client kubernetes.Interface) (*policy.PodDisruptionBudget,error) {
 	pdbList, err := client.Policy().PodDisruptionBudgets(OpenshiftMachineConfigNamespace).List(metav1.ListOptions{})
 	if err != nil {
-		return nil, false, fmt.Errorf("can't get mco pdb: %v", err)
+		return nil, fmt.Errorf("can't get mco pdb: %v", err)
 	}
 	if pdbList.Size() == 0  || pdbList.Items == nil || len(pdbList.Items) == 0 {
-		return nil, true, fmt.Errorf("mco pdb is empty")
+		return nil, fmt.Errorf("mco pdb is empty")
 	}
-	return &pdbList.Items[0], false, nil
+	return &pdbList.Items[0], nil
 }
 
 func isMasterNode(client kubernetes.Interface, node *corev1.Node) bool {
@@ -47,49 +47,11 @@ func isMasterNode(client kubernetes.Interface, node *corev1.Node) bool {
 	return false
 }
 
-func createFallbackPDB(client kubernetes.Interface) (*policy.PodDisruptionBudget,error) {
+func checkValidQuorumPdb(client kubernetes.Interface) (bool, error) {
 
-	objectName  := "etcpdb"
-	minAvailable := intstr.FromInt(1)
-	object := &policy.PodDisruptionBudget{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      objectName,
-			Namespace: NodeMaintenanceOperatorNamespace,
-		},
-		Spec: policy.PodDisruptionBudgetSpec{
-			Selector:     &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					"k8s-app": "etcd-quorum-guard",
-				},
-			},
-			MinAvailable: &minAvailable,
-		},
-		Status: policy.PodDisruptionBudgetStatus{},
-	}
-
-	_, err := client.PolicyV1beta1().PodDisruptionBudgets(NodeMaintenanceOperatorNamespace).Create(object)
+	pdb, err := findMcoPDBForEtcd(client)
 	if err != nil {
-		if errors.IsAlreadyExists(err) {
-			object, err = client.PolicyV1beta1().PodDisruptionBudgets(NodeMaintenanceOperatorNamespace).Get(objectName,metav1.GetOptions{})
-			if err != nil {
-				return nil, err
-			}
-		}
-	}
-
-	return object, nil
-}
-
-func checkValidQuorumPdb(client kubernetes.Interface) (bool, bool, error) {
-
-	fallbackPDB := false
-	pdb, pdbNotFound, err := findMcoPDBForEtcd(client)
-	if pdbNotFound {
-		fallbackPDB = true
-		pdb, err = createFallbackPDB(client)
-	}
-	if err != nil {
-		return false, false, err
+		return false, err
 	}
 
 	minAvailable := int32(pdb.Spec.MinAvailable.IntValue())
@@ -97,9 +59,9 @@ func checkValidQuorumPdb(client kubernetes.Interface) (bool, bool, error) {
 	disruptedPodLen := int32(len(pdb.Status.DisruptedPods))
 	isValidQuorum := minAvailable <= currentHealthy-disruptedPodLen-1
 
-	log.Infof("master quorum isvalid: %t machine configuration pdb: spec.minAvailable: %d current healthy: %d disruptedPods %d fallbackPDB %t", isValidQuorum, minAvailable, currentHealthy, disruptedPodLen, fallbackPDB)
+	log.Infof("master quorum isvalid: %t machine configuration pdb: spec.minAvailable: %d current healthy: %d disruptedPods %d", isValidQuorum, minAvailable, currentHealthy, disruptedPodLen)
 
-	return isValidQuorum, fallbackPDB, nil
+	return isValidQuorum, nil
 }
 
 

--- a/pkg/controller/nodemaintenance/master_quorum_check.go
+++ b/pkg/controller/nodemaintenance/master_quorum_check.go
@@ -1,0 +1,105 @@
+package nodemaintenance
+
+import (
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	policy "k8s.io/api/policy/v1beta1"
+	kubernetes "k8s.io/client-go/kubernetes"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/api/errors"
+)
+
+const OpenshiftMachineConfigNamespace = "openshift-machine-config-operator"
+
+func checkValidQuorum(client kubernetes.Interface, node *corev1.Node) (bool, bool, error) {
+	if isMasterNode(client, node) {
+		validQuorum, fallbackPDB, err := checkValidQuorumPdb(client)
+		if err != nil {
+			return false, false, err
+		}
+		log.Infof("node %s is a master. quorum status: %t", node.Name, validQuorum)
+		return validQuorum, fallbackPDB, nil
+	} else {
+		log.Infof("node %s is not a master", node.Name)
+	}
+	return true, false, nil
+}
+
+func findMcoPDBForEtcd(client kubernetes.Interface) (*policy.PodDisruptionBudget,bool,error) {
+	pdbList, err := client.Policy().PodDisruptionBudgets(OpenshiftMachineConfigNamespace).List(metav1.ListOptions{})
+	if err != nil {
+		return nil, false, fmt.Errorf("can't get mco pdb: %v", err)
+	}
+	if pdbList.Size() == 0  || pdbList.Items == nil || len(pdbList.Items) == 0 {
+		return nil, true, fmt.Errorf("mco pdb is empty")
+	}
+	return &pdbList.Items[0], false, nil
+}
+
+func isMasterNode(client kubernetes.Interface, node *corev1.Node) bool {
+	if node.ObjectMeta.Labels != nil {
+		_, isMaster := node.ObjectMeta.Labels[MasterNodeLabel]
+		return isMaster
+	}
+	return false
+}
+
+func createFallbackPDB(client kubernetes.Interface) (*policy.PodDisruptionBudget,error) {
+
+	objectName  := "etcpdb"
+	minAvailable := intstr.FromInt(1)
+	object := &policy.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      objectName,
+			Namespace: NodeMaintenanceOperatorNamespace,
+		},
+		Spec: policy.PodDisruptionBudgetSpec{
+			Selector:     &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"k8s-app": "etcd-quorum-guard",
+				},
+			},
+			MinAvailable: &minAvailable,
+		},
+		Status: policy.PodDisruptionBudgetStatus{},
+	}
+
+	_, err := client.PolicyV1beta1().PodDisruptionBudgets(NodeMaintenanceOperatorNamespace).Create(object)
+	if err != nil {
+		if errors.IsAlreadyExists(err) {
+			object, err = client.PolicyV1beta1().PodDisruptionBudgets(NodeMaintenanceOperatorNamespace).Get(objectName,metav1.GetOptions{})
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return object, nil
+}
+
+func checkValidQuorumPdb(client kubernetes.Interface) (bool, bool, error) {
+
+	fallbackPDB := false
+	pdb, pdbNotFound, err := findMcoPDBForEtcd(client)
+	if pdbNotFound {
+		fallbackPDB = true
+		pdb, err = createFallbackPDB(client)
+	}
+	if err != nil {
+		return false, false, err
+	}
+
+	minAvailable := int32(pdb.Spec.MinAvailable.IntValue())
+	currentHealthy := pdb.Status.CurrentHealthy
+	disruptedPodLen := int32(len(pdb.Status.DisruptedPods))
+	isValidQuorum := minAvailable <= currentHealthy-disruptedPodLen-1
+
+	log.Infof("master quorum isvalid: %t machine configuration pdb: spec.minAvailable: %d current healthy: %d disruptedPods %d fallbackPDB %t", isValidQuorum, minAvailable, currentHealthy, disruptedPodLen, fallbackPDB)
+
+	return isValidQuorum, fallbackPDB, nil
+}
+
+

--- a/pkg/controller/nodemaintenance/master_quorum_check.go
+++ b/pkg/controller/nodemaintenance/master_quorum_check.go
@@ -62,4 +62,3 @@ func checkValidQuorumPdb(client kubernetes.Interface) (bool, error) {
 	return isValidQuorum, nil
 }
 
-

--- a/pkg/controller/nodemaintenance/master_quorum_check.go
+++ b/pkg/controller/nodemaintenance/master_quorum_check.go
@@ -8,8 +8,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	policy "k8s.io/api/policy/v1beta1"
 	kubernetes "k8s.io/client-go/kubernetes"
-	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/apimachinery/pkg/api/errors"
 )
 
 const OpenshiftMachineConfigNamespace = "openshift-machine-config-operator"

--- a/pkg/controller/nodemaintenance/nodemaintenance_controller.go
+++ b/pkg/controller/nodemaintenance/nodemaintenance_controller.go
@@ -230,7 +230,7 @@ func (r *ReconcileNodeMaintenance) Reconcile(request reconcile.Request) (reconci
 			instance.Status.ErrorOnLeaseCount = 0
 		}
 	}
-	validQuorum, _, err := checkValidQuorum(r.drainer.Client, node)
+	validQuorum, err := checkValidQuorum(r.drainer.Client, node)
 	if err != nil {
 		err = fmt.Errorf("Can't check quorum validity: %v", err)
 		log.Error(err)

--- a/test/e2e/nodemaintenance_quorumsize_test.go
+++ b/test/e2e/nodemaintenance_quorumsize_test.go
@@ -1,0 +1,211 @@
+package e2e
+
+import (
+	goctx "context"
+	"fmt"
+	"testing"
+	"time"
+	operator "kubevirt.io/node-maintenance-operator/pkg/apis/nodemaintenance/v1beta1"
+	nmo "kubevirt.io/node-maintenance-operator/pkg/controller/nodemaintenance"
+	nmooperator "kubevirt.io/node-maintenance-operator/pkg/controller/nodemaintenance"
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	policy "k8s.io/api/policy/v1beta1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func createEtcPDB(t *testing.T, f *framework.Framework, ctx *framework.TestCtx) (*policy.PodDisruptionBudget, *corev1.Namespace, error) {
+
+	nsobject := &corev1.Namespace{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Namespace",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nmooperator.OpenshiftMachineConfigNamespace,
+			Labels: map[string]string{
+				"name":	nmooperator.OpenshiftMachineConfigNamespace,
+			},
+		},
+	}
+	err := f.Client.Create(goctx.TODO(), nsobject, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+	if err != nil {
+		return nil, nil, fmt.Errorf("can't create namespace : %v", err)
+	}
+
+	objectName  := "etcpdb"
+	minAvailable := intstr.FromInt(1)
+	object := &policy.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      objectName,
+			Namespace: nmooperator.OpenshiftMachineConfigNamespace,
+		},
+		Spec: policy.PodDisruptionBudgetSpec{
+			Selector:     &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"k8s-app": "etcd-quorum-guard",
+				},
+			},
+			MinAvailable: &minAvailable,
+		},
+		Status: policy.PodDisruptionBudgetStatus{},
+	}
+
+	err = f.Client.Create(goctx.TODO(), object, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+	if err != nil {
+		f.Client.Delete(goctx.TODO(), nsobject)
+		return nil, nil, err
+	}
+	return object, nsobject, nil
+}
+
+func checkQuorumSizeViolation(t *testing.T, f *framework.Framework, ctx *framework.TestCtx) error {
+
+	pdb, nsobject, err := createEtcPDB(t , f , ctx )
+	if err != nil {
+		showDeploymentStatus(t, f, fmt.Errorf("can't create test pdb :  %v", err))
+	}
+	t.Logf("test etc PDB created")
+
+	namespace, err := ctx.GetNamespace()
+	if err != nil {
+		return fmt.Errorf("could not get namespace: %v", err)
+	}
+
+	err = createSimpleDeployment(t, f, ctx, namespace, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nodeName, err := getCurrentDeploymentHostName(t, f)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+
+	node := &corev1.Node{}
+	err = f.Client.Get(goctx.TODO(), types.NamespacedName{Namespace: namespace, Name: nodeName}, node)
+	if err != nil {
+		showDeploymentStatus(t, f, fmt.Errorf("Failed to get node %s : %v", nodeName, err))
+	}
+
+	_, isMaster := node.ObjectMeta.Labels[nmo.MasterNodeLabel]
+	if !isMaster {
+		showDeploymentStatus(t, f, fmt.Errorf("node %s is not a master node",nodeName))
+	}
+
+	t.Logf("Putting master node %s into maintanance", nodeName)
+
+	// Create node maintenance custom resource
+	nodeMaintenance := &operator.NodeMaintenance{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "NodeMaintenance",
+			APIVersion: "nodemaintenance.kubevirt.io/v1beta1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "nodemaintenance-xyz",
+		},
+		Spec: operator.NodeMaintenanceSpec{
+			NodeName: nodeName,
+			Reason:   "Set maintenance on node for e2e testing",
+		},
+	}
+
+// Create node maintenance CR
+	err = f.Client.Create(goctx.TODO(), nodeMaintenance, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+	if err != nil {
+		t.Fatalf("Can't create CRD: %v", err)
+	}
+
+	// Get Running phase first
+	if err := wait.PollImmediate(1*time.Second, 20*time.Second, func() (bool, error) {
+		nm := &operator.NodeMaintenance{}
+		err := f.Client.Get(goctx.TODO(), types.NamespacedName{Name: "nodemaintenance-xyz"}, nm)
+		if err != nil {
+			t.Logf("Failed to get %q nodeMaintenance: %v", nm.Name, err)
+			return false, nil
+		}
+
+		//t.Logf("%s: operator running state: %s", time.Now().Format("2006-01-02 15:04:05.000000"), nm.Status.Phase)
+		if nm.Status.Phase != operator.MaintenanceRunning {
+			t.Logf("%s: Running", time.Now().Format("2006-01-02 15:04:05.000000"))
+			return false, nil
+		}
+
+		if nm.Status.LastError != nmo.QuorumViolationErrorMsg {
+			t.Logf("%s: Running, with wrong error: %s", time.Now().Format("2006-01-02 15:04:05.000000"), nm.Status.LastError)
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		showDeploymentStatus(t, f, fmt.Errorf("%s: Failed to verify running phase: %v", time.Now().Format("2006-01-02 15:04:05.000000"), err))
+	}
+
+	t.Logf("correct error has been observed")
+	t.Logf("delete nmo for node  %s", nodeName)
+
+	nodeMaintenanceDelete := &operator.NodeMaintenance{}
+
+	err = f.Client.Get(goctx.TODO(), types.NamespacedName{Namespace: nodeMaintenance.Namespace, Name: nodeMaintenance.Name}, nodeMaintenanceDelete)
+	if err != nil {
+		showDeploymentStatus(t, f, fmt.Errorf("Failed to get CRD. error %v", err))
+	}
+
+	// Delete the node maintenance custom resource
+	err = f.Client.Delete(goctx.TODO(), nodeMaintenanceDelete)
+	if err != nil {
+		showDeploymentStatus(t, f, fmt.Errorf("Could not delete node maintenance CR : %v", err))
+	}
+
+	if err := wait.PollImmediate(5*time.Second, 120*time.Second, func() (bool, error) {
+		nm := &operator.NodeMaintenance{}
+		err := f.Client.Get(goctx.TODO(), types.NamespacedName{Name: "nodemaintenance-xyz"}, nm)
+		if err == nil {
+			return false, nil
+		}
+		if !errors.IsNotFound(err) {
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		showDeploymentStatus(t, f, fmt.Errorf("%s: Failed to verify that nmo has been deleted %v", time.Now().Format("2006-01-02 15:04:05.000000"), err))
+	}
+
+
+	node = &corev1.Node{}
+	err = f.Client.Get(goctx.TODO(), types.NamespacedName{Namespace: namespace, Name: nodeName}, node)
+	if err != nil {
+		showDeploymentStatus(t, f, fmt.Errorf("can't get node. error %v", err))
+	}
+
+	// Check that the deployment has 1 replica running after maintenance is removed.
+	t.Logf("%s: wait for deployment.", time.Now().Format("2006-01-02 15:04:05.000000"))
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, testDeployment, 1, retryInterval, timeout)
+	if err != nil {
+		showDeploymentStatus(t, f, fmt.Errorf("%s: failed to wait for deployment. error %v.", err, time.Now().Format("2006-01-02 15:04:05.000000")))
+	}
+
+	err = deleteSimpleDeployment(t, f, ctx, namespace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("test deployment deleted")
+	t.Logf("test checkQuorumSizeViolation completed successfully")
+
+	err = f.Client.Delete(goctx.TODO(), pdb)
+	if err != nil {
+		showDeploymentStatus(t, f, fmt.Errorf("can't delete test pdb : %v", err))
+	}
+	err = f.Client.Delete(goctx.TODO(), nsobject)
+	if err != nil {
+		showDeploymentStatus(t, f, fmt.Errorf("can't delete namespace : %v", err))
+	}
+	return nil
+}
+
+


### PR DESCRIPTION
Check that the node to be taken into maintenance mode is a master node; if that is the case, then  then the number of  available master nodes is not allowed to drop below the required quorum size. Fail the reconcile request with error if that is about to happen.

Unit tests are implemented as table tests.
 
This was added as a fix for: https://bugzilla.redhat.com/show_bug.cgi?id=1826914

**Release note:**
```release-note
Check that the node to be taken into maintenance mode is a master node; if that is the case, then then the number of available master nodes is not allowed to drop below the required quorum size. Fail the reconcile request with error if that is about to happen.
```