### PR TITLE
fix intermittent failure to start unit test runner

### DIFF
--- a/hack/coverage.sh
+++ b/hack/coverage.sh
@@ -19,8 +19,9 @@ MAX_REPEAT_COUNT=10
 while [[ $REPEAT_COUNT -lt $MAX_REPEAT_COUNT ]]; do
 
 		# run ginkgo with coverage result line
-		${GINKGO} ${GINKGO_ARGS} ./pkg/ ./cmd/ 2>&1 | sed  '/coverage:.*$/d'  | tee msg
+		GINKGO_OUT=$(${GINKGO} ${GINKGO_ARGS} ./pkg/ ./cmd/ 2>&1 | sed  '/coverage:.*$/d')
 		GSTAT=${PIPESTATUS[0]}
+		echo "$GINKGO_OUT"
 
 		if [[ $GSTAT -eq 0 ]]; then
 			break
@@ -29,7 +30,7 @@ while [[ $REPEAT_COUNT -lt $MAX_REPEAT_COUNT ]]; do
 		# sometimes the error message is 'Unable to read coverage file' for no apparent reason
 		# repeat the test if that is so.
 		set +e
-		grep "Unable to read coverage file" ./msg
+		echo "$GINKGO_OUT" | grep "Unable to read coverage file"
 		STAT=$?
 		set -e
 

--- a/hack/coverage.sh
+++ b/hack/coverage.sh
@@ -4,7 +4,6 @@ GINKGO="$1"
 TARGETCOVERAGE="$2"
 
 COVERAGE_FILE=cover.out
-
 GINKGO_COVERAGE_ARGS="-cover -coverprofile=${COVERAGE_FILE} -outputdir=.  --skipPackage ./vendor"
 GINKGO_ARGS="-v -r --progress ${GINKGO_EXTRA_ARGS} ${GINKGO_COVERAGE_ARGS}"
 

--- a/hack/coverage.sh
+++ b/hack/coverage.sh
@@ -5,7 +5,6 @@ TARGETCOVERAGE="$2"
 
 COVERAGE_FILE=cover.out
 
-#GINKGO_COVERAGE_ARGS="-coverpkg  ./,./pkg/controller/nodemaintenance -coverprofile=${COVERAGE_FILE} -outputdir=.  --skipPackage ./vendor"
 GINKGO_COVERAGE_ARGS="-cover -coverprofile=${COVERAGE_FILE} -outputdir=.  --skipPackage ./vendor"
 GINKGO_ARGS="-v -r --progress ${GINKGO_EXTRA_ARGS} ${GINKGO_COVERAGE_ARGS}"
 
@@ -15,7 +14,9 @@ declare -a EXCLUDE_FILES_FROM_COVERAGE=("nodemaintenance_controller_init.go")
 # delete coverage files (if present)
 find . -name ${COVERAGE_FILE} | xargs rm -f
 
-while [ true ]; do
+REPEAT_COUNT=0
+MAX_REPEAT_COUNT=10
+while [[ $REPEAT_COUNT -lt $MAX_REPEAT_COUNT ]]; do
 
 		# run ginkgo with coverage result line
 		${GINKGO} ${GINKGO_ARGS} ./pkg/ ./cmd/ 2>&1 | sed  '/coverage:.*$/d'  | tee msg
@@ -36,6 +37,7 @@ while [ true ]; do
 			break
 		fi
 		echo "repeating ginkgo run, unable to read coverage"
+		((REPEAT_COUNT+=1))
 done
 
 if [[ $GSTAT != 0 ]]; then

--- a/hack/coverage.sh
+++ b/hack/coverage.sh
@@ -28,6 +28,9 @@ while [[ $REPEAT_COUNT -lt $MAX_REPEAT_COUNT ]]; do
 
 		# sometimes the error message is 'Unable to read coverage file' for no apparent reason
 		# repeat the test if that is so.
+		#
+		# See also: https://github.com/onsi/ginkgo/issues/417
+		#  'coverage:' lines hold no clue and unsetting -outputdir produced no effect
 		set +e
 		echo "$GINKGO_OUT" | grep "Unable to read coverage file"
 		STAT=$?


### PR DESCRIPTION
Occasionally ginkgo test run fails to start, the error message in this
case is 'unable to combine coverage'
This condition is fixed by repeating the test run.

The full error log for a failed test run:

      quorum broken
      /home/mmoser/go/src/kubevirt.io/node-maintenance-operator/vendor/github.com/onsi/ginkgo/extensions/table/table_entry.go:43
    [It] quorum broken
      /home/mmoser/go/src/kubevirt.io/node-maintenance-operator/vendor/github.com/onsi/ginkgo/extensions/table/table_entry.go:43
    path is /home/mmoser/go/src/kubevirt.io/node-maintenance-operator
    Unable to read coverage file pkg/controller/nodemaintenance/cover.out to combine, open pkg/controller/nodemaintenance/cover.out: no such file or directory

Signed-off-by: Michael Moser <mmoser@redhat.com>