### PR TITLE
make cluster-clean broken after using new ci 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,6 @@ cluster-functest:
 	./hack/functest.sh
 
 cluster-clean:
-	$(KUBEVIRTCI_PATH)/clean.sh
+	./hack/clean.sh
 
 .PHONY: all check fmt test container-build container-push manifests verify-manifests cluster-up cluster-down cluster-sync cluster-functest cluster-clean pull-ci-changes test-courier

--- a/hack/clean.sh
+++ b/hack/clean.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+echo 'Cleaning up ...'
+
+
+./kubevirtci/cluster-up/kubectl.sh delete --ignore-not-found -f _out/namespace-init.yaml
+./kubevirtci/cluster-up/kubectl.sh delete --ignore-not-found -f _out/nodemaintenance_crd.yaml
+./kubevirtci/cluster-up/kubectl.sh delete --ignore-not-found -f deploy/namespace.yaml
+


### PR DESCRIPTION
make cluster-clean stopped working after using new upstream ci.
wasn't noticed  as this is not used in build process.

Signed-off-by: Michael Moser <mmoser@redhat.com>