### PR TITLE
Fix "external" CI provider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ pull-ci-changes:
 	git subtree pull --prefix kubevirtci https://github.com/kubevirt/kubevirtci.git master --squash
 
 cluster-sync:
-	./hack/sync.sh
+	IMAGE_REGISTRY=$(IMAGE_REGISTRY) IMAGE_TAG=$(IMAGE_TAG) ./hack/sync.sh
 
 cluster-functest:
 	./hack/functest.sh

--- a/hack/functest.sh
+++ b/hack/functest.sh
@@ -37,7 +37,7 @@ cat _out/namespace-init.yaml
 # Run tests
 
 find . -name .kubeconfig || true
-KUBE_CONFIG=$(${KUBEVIRTCI_PATH}/kubeconfig.sh)
+KUBE_CONFIG=${KUBECONFIG:-$(${KUBEVIRTCI_PATH}/kubeconfig.sh)}
 
 TEST_NAMESPACE=node-maintenance-operator GOFLAGS="-mod=vendor" go test ./test/e2e/... -root=$(pwd) -kubeconfig=${KUBE_CONFIG} -globalMan _out/nodemaintenance_crd.yaml --namespacedMan _out/namespace-init.yaml -singleNamespace
 


### PR DESCRIPTION
Fixed usage of the "external" KubevirtCI provider:

- pass image registry and tag to sync script
- skip usage of cluster registry for external provider
- use existing KUBECONFIG var for functest

After this you can use an existing cluster (assuming a correctly configured KUBECONFIG) for deploying and running functests, e.g.

```
export KUBEVIRT_PROVIDER=external
export IMAGE_REGISTRY=quay.io/<user>
make container-build container-push cluster-up cluster-sync cluster-functest
```
