### PR TITLE
automation test: use the same go version as specified in .travis.yml

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -7,16 +7,24 @@ export GOPATH=$(pwd)/go
 export PATH=$GOPATH/bin:$GOROOT/bin:$PATH
 mkdir -p $GOPATH
 
-echo "Install Go 1.10"
-export GIMME_GO_VERSION=1.11.5
-mkdir -p /gimme
-curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | HOME=/gimme bash >> /etc/profile.d/gimme.sh
-source /etc/profile.d/gimme.sh
-
 echo "Install operator repository to the right place"
 mkdir -p $GOPATH/src/kubevirt.io
 mkdir -p $GOPATH/pkg
 ln -s $(pwd)/node-maintenance-operator $GOPATH/src/kubevirt.io/
+
+pushd $GOPATH/src/kubevirt.io/node-maintenance-operator
+GO_VERSION=$(yq r .travis.yml go) || true
+if [[ $GO_VERSION == "" ]]; then
+	GO_VERSION=$(grep go: .travis.yml  | awk '{ print $2 }' | sed -e 's/"\([^"]*\)"$/\1/')
+fi
+popd
+
+echo "install go version speciifed in travis: ${GO_VERSION}"
+export GIMME_GO_VERSION=${GO_VERSION}
+mkdir -p /gimme
+curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | HOME=/gimme bash >> /etc/profile.d/gimme.sh
+source /etc/profile.d/gimme.sh
+
 cd $GOPATH/src/kubevirt.io/node-maintenance-operator
 
 kubectl() { cluster/kubectl.sh "$@"; }


### PR DESCRIPTION
moved version in .travis.yml - but automation test use their own gimme
invocation. change automation test script to use the same version,

Signed-off-by: Michael Moser <mmoser@redhat.com>