### PR TITLE
whitespace fixes as precommit hook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,6 @@ cluster-clean:
 
 setupgithook:
 	./hack/precommit-hook.sh setup
-	./hack/prepare-commit-msg-hook.sh setup
+	./hack/commit-msg-hook.sh setup
 
 PHONY: all check fmt test container-build container-push manifests verify-manifests cluster-up cluster-down cluster-sync cluster-functest cluster-clean pull-ci-changes test-courier setupgithook whitespace-commit

--- a/hack/commit-msg-hook.sh
+++ b/hack/commit-msg-hook.sh
@@ -8,8 +8,8 @@ if [[ $TOP_LEVEL == "" ]]; then
 fi
 
 if [[ $1 == "setup" ]]; then
-	if [[ ! -f $TOP_LEVEL/.git/hooks/prepare-commit-msg ]] && [[ ! -h $TOP_LEVEL/.git/hooks/prepare-commit-msg ]]; then
-		ln -s  $TOP_LEVEL/hack/prepare-commit-msg-hook.sh $TOP_LEVEL/.git/hooks/prepare-commit-msg
+	if [[ ! -f $TOP_LEVEL/.git/hooks/commit-msg ]] && [[ ! -h $TOP_LEVEL/.git/hooks/commit-msg ]]; then
+		ln -s  $TOP_LEVEL/hack/commit-msg-hook.sh $TOP_LEVEL/.git/hooks/commit-msg
 	fi
 	exit 0
 fi
@@ -23,10 +23,9 @@ if [[ $HAS_SIGNOFF == "0" ]]; then
 	exec 1>&2
 	cat <<EOF
 Commit Signoff is missing from the commit message.
+Please create the commit with the following commit
 
-Please add the signoff message with the following command:
-
-	git commit --amend --signoff
+	git commit  --signoff
 EOF
 	exit 1
 fi

--- a/hack/precommit-hook.sh
+++ b/hack/precommit-hook.sh
@@ -2,14 +2,14 @@
 
 TOP_LEVEL=$(git rev-parse --show-toplevel)
 
-if [[ $1 == "setup" ]]; then
-	ln -fs  $TOP_LEVEL/hack/precommit-hook.sh $TOP_LEVEL/.git/hooks/pre-commit
-	exit 0
-fi
-
 if [[ $TOP_LEVEL == "" ]]; then
   echo "Error: this script must be called from a git repository"
   exit 1
+fi
+
+if [[ $1 == "setup" ]]; then
+	ln -fs  $TOP_LEVEL/hack/precommit-hook.sh $TOP_LEVEL/.git/hooks/pre-commit
+	exit 0
 fi
 
 # Redirect output to stderr.

--- a/hack/precommit-hook.sh
+++ b/hack/precommit-hook.sh
@@ -8,7 +8,9 @@ if [[ $TOP_LEVEL == "" ]]; then
 fi
 
 if [[ $1 == "setup" ]]; then
-	ln -fs  $TOP_LEVEL/hack/precommit-hook.sh $TOP_LEVEL/.git/hooks/pre-commit
+	if [[ ! -f $TOP_LEVEL/.git/hooks/pre-commit ]] && [[ ! -h $TOP_LEVEL/.git/hooks/pre-commit ]]; then
+		ln -s  $TOP_LEVEL/hack/precommit-hook.sh $TOP_LEVEL/.git/hooks/pre-commit
+	fi
 	exit 0
 fi
 

--- a/hack/precommit-hook.sh
+++ b/hack/precommit-hook.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+TOP_LEVEL=$(git rev-parse --show-toplevel)
+
+if [[ $1 == "setup" ]]; then
+	ln -fs  $TOP_LEVEL/hack/precommit-hook.sh $TOP_LEVEL/.git/hooks/pre-commit
+	exit 0
+fi
+
+if [[ $TOP_LEVEL == "" ]]; then
+  echo "Error: this script must be called from a git repository"
+  exit 1
+fi
+
+# Redirect output to stderr.
+exec 1>&2
+
+cd $TOP_LEVEL
+${TOP_LEVEL}/hack/whitespace.sh --check-precommit
+if [[ $? != 0 ]]; then
+	echo "Error: whitespace check failed. run make whitespace to fix it (or make whitespace-commit to change just the files added for commit)"
+	exit 1
+fi

--- a/hack/prepare-commit-msg-hook.sh
+++ b/hack/prepare-commit-msg-hook.sh
@@ -2,18 +2,22 @@
 
 TOP_LEVEL=$(git rev-parse --show-toplevel)
 
-if [[ $1 == "setup" ]]; then
-	ln -fs  $TOP_LEVEL/hack/prepare-commit-msg-hook.sh $TOP_LEVEL/.git/hooks/prepare-commit-msg
-	exit 0
-fi
-
 if [[ $TOP_LEVEL == "" ]]; then
   echo "Error: this script must be called from a git repository"
   exit 1
 fi
 
-COMMIT_MSG_FILE="$1"
-SIGNOFF_MSG="Signed-off-by: "$(git config user.name)" <"$(git config user.email)">" >>${COMMIT_MSG_FILE}
-sed -ie "1i ${SIGNOFF_MSG}" "${COMMIT_MSG_FILE}"
+if [[ $1 == "setup" ]]; then
+	ln -fs  $TOP_LEVEL/hack/prepare-commit-msg-hook.sh $TOP_LEVEL/.git/hooks/prepare-commit-msg
+	exit 0
+fi
 
+UNAME=$(git config user.name)
+UMAIL=$(git config user.email)
+
+if [[ $UNAME != "" ]] && [[ $UMAIL != "" ]]; then
+	COMMIT_MSG_FILE="$1"
+	SIGNOFF_MSG="Signed-off-by: ${UNAME} <${UMAIL}>"
+	sed -ie "1i ${SIGNOFF_MSG}" "${COMMIT_MSG_FILE}"
+fi
 

--- a/hack/prepare-commit-msg-hook.sh
+++ b/hack/prepare-commit-msg-hook.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+TOP_LEVEL=$(git rev-parse --show-toplevel)
+
+if [[ $1 == "setup" ]]; then
+	ln -fs  $TOP_LEVEL/hack/prepare-commit-msg-hook.sh $TOP_LEVEL/.git/hooks/prepare-commit-msg
+	exit 0
+fi
+
+if [[ $TOP_LEVEL == "" ]]; then
+  echo "Error: this script must be called from a git repository"
+  exit 1
+fi
+
+COMMIT_MSG_FILE="$1"
+SIGNOFF_MSG="Signed-off-by: "$(git config user.name)" <"$(git config user.email)">" >>${COMMIT_MSG_FILE}
+sed -ie "1i ${SIGNOFF_MSG}" "${COMMIT_MSG_FILE}"
+
+

--- a/hack/prepare-commit-msg-hook.sh
+++ b/hack/prepare-commit-msg-hook.sh
@@ -16,27 +16,18 @@ fi
 
 COMMIT_MSG_FILE="$1"
 
-# check if commit message is empty
+# check if commit message is present
 HAS_SIGNOFF=$(grep -c 'Signed-off-by:' "${COMMIT_MSG_FILE}")
 
 if [[ $HAS_SIGNOFF == "0" ]]; then
-	UNAME=$(git config user.name)
-	UMAIL=$(git config user.email)
+	exec 1>&2
+	cat <<EOF
+Commit Signoff is missing from the commit message.
 
-	if [[ $UNAME != "" ]] && [[ $UMAIL != "" ]]; then
+Please add the signoff message with the following command:
 
-		COMMIT_COMMENTS=$(sed -n 's/\(^#.*$\)/\1/p' "${COMMIT_MSG_FILE}")
-
-		SIGNOFF_MSG="Signed-off-by: ${UNAME} <${UMAIL}>"
-
-		# strip comments
-		sed -i '/^#.*$/d' "${COMMIT_MSG_FILE}"
-
-		# add signoff
-		echo -e "\n${SIGNOFF_MSG}\n" >>${COMMIT_MSG_FILE}
-
-		# add comments back
-		echo "${COMMIT_COMMENTS}"  >>${COMMIT_MSG_FILE}
-	fi
+	git commit --amend --signoff
+EOF
+	exit 1
 fi
 

--- a/hack/prepare-commit-msg-hook.sh
+++ b/hack/prepare-commit-msg-hook.sh
@@ -8,16 +8,35 @@ if [[ $TOP_LEVEL == "" ]]; then
 fi
 
 if [[ $1 == "setup" ]]; then
-	ln -fs  $TOP_LEVEL/hack/prepare-commit-msg-hook.sh $TOP_LEVEL/.git/hooks/prepare-commit-msg
+	if [[ ! -f $TOP_LEVEL/.git/hooks/prepare-commit-msg ]] && [[ ! -h $TOP_LEVEL/.git/hooks/prepare-commit-msg ]]; then
+		ln -s  $TOP_LEVEL/hack/prepare-commit-msg-hook.sh $TOP_LEVEL/.git/hooks/prepare-commit-msg
+	fi
 	exit 0
 fi
 
-UNAME=$(git config user.name)
-UMAIL=$(git config user.email)
+COMMIT_MSG_FILE="$1"
 
-if [[ $UNAME != "" ]] && [[ $UMAIL != "" ]]; then
-	COMMIT_MSG_FILE="$1"
-	SIGNOFF_MSG="Signed-off-by: ${UNAME} <${UMAIL}>"
-	sed -ie "1i ${SIGNOFF_MSG}" "${COMMIT_MSG_FILE}"
+# check if commit message is empty
+HAS_SIGNOFF=$(grep -c 'Signed-off-by:' "${COMMIT_MSG_FILE}")
+
+if [[ $HAS_SIGNOFF == "0" ]]; then
+	UNAME=$(git config user.name)
+	UMAIL=$(git config user.email)
+
+	if [[ $UNAME != "" ]] && [[ $UMAIL != "" ]]; then
+
+		COMMIT_COMMENTS=$(sed -n 's/\(^#.*$\)/\1/p' "${COMMIT_MSG_FILE}")
+
+		SIGNOFF_MSG="Signed-off-by: ${UNAME} <${UMAIL}>"
+
+		# strip comments
+		sed -i '/^#.*$/d' "${COMMIT_MSG_FILE}"
+
+		# add signoff
+		echo -e "\n${SIGNOFF_MSG}\n" >>${COMMIT_MSG_FILE}
+
+		# add comments back
+		echo "${COMMIT_COMMENTS}"  >>${COMMIT_MSG_FILE}
+	fi
 fi
 

--- a/hack/whitespace.sh
+++ b/hack/whitespace.sh
@@ -16,7 +16,7 @@ function check_files {
 
 		if [[ "$IDEAL_FILE" != "$REAL_FILE" ]]; then
 			echo "need whitespace fix for file $fname"
-			#diff -u $(echo "$REAL_FILE") $(echo "$IDEAL_FILE")
+			diff -u <(echo "$REAL_FILE") <(echo "$IDEAL_FILE")
 		fi
 	done
 }

--- a/hack/whitespace.sh
+++ b/hack/whitespace.sh
@@ -9,14 +9,41 @@ function fix_one_file() {
 	rm -f ${fname}.tmp
 }
 
+function check_files {
+	while read fname; do
+		IDEAL_FILE=$(sed --follow-symlinks 's/[[:space:]]*$//' ${fname} | sed 'N;/^\n$/D;P;D;')
+		REAL_FILE=$(cat ${fname})
+
+		if [[ "$IDEAL_FILE" != "$REAL_FILE" ]]; then
+			echo "need whitespace fix for file $fname"
+			#diff -u $(echo "$REAL_FILE") $(echo "$IDEAL_FILE")
+		fi
+	done
+}
+
 export -f fix_one_file
 
 function fix() {
     git ls-files -- ':!vendor/' | grep -vE '^kubevirtci/' | xargs -I {} bash -c 'fix_one_file "{}"'
 }
 
+function fix_commit() {
+    git diff --cached --name-only | grep -vE '^vendor/' | grep -vE '^kubevirtci/' | xargs -I {} bash -c 'fix_one_file "{}"'
+}
+
 function check() {
-    invalid_files=$(git ls-files -- ':!vendor/' | grep -vE '^kubevirtci/' | xargs egrep -Hn " +$" || true)
+	invalid_files=$(git ls-files -- ':!vendor/' | grep -vE '^kubevirtci/' | check_files)
+
+    if [[ $invalid_files ]]; then
+        echo 'Found trailing whitespaces. Please remove trailing whitespaces using `make fmt`:'
+        echo "$invalid_files"
+        return 1
+    fi
+}
+
+function check_precommit() {
+	invalid_files=$(git diff --cached --name-only | grep -vE '^vendor/' | grep -vE '^kubevirtci/' | check_files)
+
     if [[ $invalid_files ]]; then
         echo 'Found trailing whitespaces. Please remove trailing whitespaces using `make fmt`:'
         echo "$invalid_files"
@@ -26,6 +53,10 @@ function check() {
 
 if [ "$1" == "--fix" ]; then
     fix
+elif [ "$1" == "--fix-commit" ]; then
+    fix_commit
+elif [ "$1" == "--check-precommit" ]; then
+    check_precommit
 else
     check
 fi


### PR DESCRIPTION
- make check installs a pre-commit hook that reports whitespace issues (trailing whitespace or multiple empty lines). the pre-commit hook checks files that are about to be commited for whitespace problems.
- make whitespace-check now reports files with multiple empty lines as errors.
- make whitepace-commit : fixes whitespace issues in files added for commit with git add.
- while we are at here: also add git hook that sets the signoff message into the commit message, so that you don't have to do git commit --amend --signoff 

The rational for these changes is that it is more appropriate to fix trailing whitespaces and multiple empty lines when you are about to commit something