### PR TITLE
set owner ref on nmo CR to the node object

### DIFF
--- a/pkg/controller/nodemaintenance/nodemaintenance_controller.go
+++ b/pkg/controller/nodemaintenance/nodemaintenance_controller.go
@@ -256,8 +256,8 @@ func (r *ReconcileNodeMaintenance) Reconcile(request reconcile.Request) (reconci
 	return reconcile.Result{}, nil
 }
 
-func makeBoolRef(val bool) (*bool) {
-	return &val;
+func makeBoolRef(val bool) *bool {
+	return &val
 }
 
 func setOwnerRefToNode(instance *nodemaintenanceapi.NodeMaintenance, node *corev1.Node) {

--- a/pkg/controller/nodemaintenance/nodemaintenance_controller.go
+++ b/pkg/controller/nodemaintenance/nodemaintenance_controller.go
@@ -169,9 +169,9 @@ func (r *ReconcileNodeMaintenance) Reconcile(request reconcile.Request) (reconci
 		reqLogger.Infof("Deletion timestamp not zero")
 
 		// The object is being deleted
-		if ContainsString(instance.ObjectMeta.Finalizers, nodemaintenanceapi.NodeMaintenanceFinalizer) {
+		if ContainsString(instance.ObjectMeta.Finalizers, nodemaintenanceapi.NodeMaintenanceFinalizer) || ContainsString(instance.ObjectMeta.Finalizers, metav1.FinalizerOrphanDependents)  {
 			// Stop node maintenance - uncordon and remove live migration taint from the node.
-			if err := r.stopNodeMaintenance(instance.Spec.NodeName); err != nil {
+			if err := r.stopNodeMaintenanceOnDeletion(instance.Spec.NodeName); err != nil {
 				reqLogger.Infof("error stopping node maintenance: %v", err)
 				if errors.IsNotFound(err) == false {
 					return r.reconcileAndError(instance, err)
@@ -200,6 +200,8 @@ func (r *ReconcileNodeMaintenance) Reconcile(request reconcile.Request) (reconci
 	if err != nil {
 		return r.reconcileAndError(instance, err)
 	}
+
+	setOwnerRefToNode(instance, node)
 
 	updateOwnedLeaseFailed, err := r.obtainLease(node)
 	if err != nil && updateOwnedLeaseFailed {
@@ -254,6 +256,37 @@ func (r *ReconcileNodeMaintenance) Reconcile(request reconcile.Request) (reconci
 	return reconcile.Result{}, nil
 }
 
+
+func setOwnerRefToNode(instance *nodemaintenanceapi.NodeMaintenance, node *corev1.Node) (bool) {
+
+	objectRefIsSet := false
+	for _, ref := range instance.ObjectMeta.GetOwnerReferences() {
+		if ref.APIVersion == node.TypeMeta.APIVersion && ref.Kind == node.TypeMeta.Kind && ref.Name == node.ObjectMeta.GetName() && ref.UID == node.ObjectMeta.GetUID() {
+			objectRefIsSet = true
+			break
+		}
+	}
+
+	if !objectRefIsSet {
+		log.Info("setting owner ref to node")
+
+		blockOwnerDeletion := false
+		controllerDeletion := false
+		nodeMeta := node.TypeMeta
+		ref := metav1.OwnerReference{
+				APIVersion:         nodeMeta.APIVersion,
+				Kind:               nodeMeta.Kind,
+				Name:               node.ObjectMeta.GetName(),
+				UID:                node.ObjectMeta.GetUID(),
+				BlockOwnerDeletion: &blockOwnerDeletion, // false - deletion of node doesn't have to wait for nmo CR deletion
+				Controller:         &controllerDeletion, // false - can delete nmo without deleting the node
+			}
+
+		instance.ObjectMeta.SetOwnerReferences( append(instance.ObjectMeta.GetOwnerReferences(), ref) )
+	}
+	return !objectRefIsSet
+}
+
 func (r *ReconcileNodeMaintenance) obtainLease(node *corev1.Node) (bool, error) {
 	if !r.isLeaseSupported {
 		return false, nil
@@ -297,9 +330,18 @@ func (r *ReconcileNodeMaintenance) stopNodeMaintenanceImp(node *corev1.Node ) er
 	return nil
 }
 
-func (r *ReconcileNodeMaintenance) stopNodeMaintenance(nodeName string) error {
+func (r *ReconcileNodeMaintenance) stopNodeMaintenanceOnDeletion(nodeName string) error {
 	node, err := r.fetchNode(nodeName)
 	if err != nil {
+		// if CR is gathered as result of garbage collection: the node may have been deleted, but the CR has not yet been deleted, still we must clean up the lease!
+		if errors.IsNotFound(err) {
+			if r.isLeaseSupported {
+				if err := invalidateLease(r.client, nodeName); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
 		return err
 	}
 	return r.stopNodeMaintenanceImp(node)

--- a/pkg/controller/nodemaintenance/nodemaintenance_controller_test.go
+++ b/pkg/controller/nodemaintenance/nodemaintenance_controller_test.go
@@ -112,8 +112,7 @@ var _ = Describe("updateCondition", func() {
 			err := cl.Get(context.TODO(), req.NamespacedName, maintanance)
 			node, err := cs.CoreV1().Nodes().Get("node01", metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			hasSetRef := setOwnerRefToNode(maintanance, node)
-			Expect(hasSetRef).To(Equal(true))
+			setOwnerRefToNode(maintanance, node)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(maintanance.ObjectMeta.GetOwnerReferences())).To(Equal(1))
 			ref := maintanance.ObjectMeta.GetOwnerReferences()[0]
@@ -121,8 +120,7 @@ var _ = Describe("updateCondition", func() {
 			Expect(ref.UID).To(Equal(node.ObjectMeta.UID))
 			Expect(ref.APIVersion).To(Equal(node.TypeMeta.APIVersion))
 			Expect(ref.Kind).To(Equal(node.TypeMeta.Kind))
-			hasSetRef = setOwnerRefToNode(maintanance, node)
-			Expect(hasSetRef).To(Equal(false))
+			setOwnerRefToNode(maintanance, node)
 			Expect(len(maintanance.ObjectMeta.GetOwnerReferences())).To(Equal(1))
 		})
 		It("Should not init Node maintenanace if already set", func() {

--- a/pkg/controller/nodemaintenance/nodemaintenance_controller_test.go
+++ b/pkg/controller/nodemaintenance/nodemaintenance_controller_test.go
@@ -113,7 +113,6 @@ var _ = Describe("updateCondition", func() {
 			node, err := cs.CoreV1().Nodes().Get("node01", metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			setOwnerRefToNode(maintanance, node)
-			Expect(err).NotTo(HaveOccurred())
 			Expect(len(maintanance.ObjectMeta.GetOwnerReferences())).To(Equal(1))
 			ref := maintanance.ObjectMeta.GetOwnerReferences()[0]
 			Expect(ref.Name).To(Equal(node.ObjectMeta.Name))

--- a/pkg/controller/nodemaintenance/nodemaintenance_controller_test.go
+++ b/pkg/controller/nodemaintenance/nodemaintenance_controller_test.go
@@ -106,6 +106,25 @@ var _ = Describe("updateCondition", func() {
 			Expect(maintanance.Status.EvictionPods).To(Equal(2))
 			Expect(maintanance.Status.TotalPods).To(Equal(2))
 		})
+		It("owner ref should be set properly", func() {
+			r.initMaintenanceStatus(nm)
+			maintanance := &nodemaintenanceapi.NodeMaintenance{}
+			err := cl.Get(context.TODO(), req.NamespacedName, maintanance)
+			node, err := cs.CoreV1().Nodes().Get("node01", metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			hasSetRef := setOwnerRefToNode(maintanance, node)
+			Expect(hasSetRef).To(Equal(true))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(maintanance.ObjectMeta.GetOwnerReferences())).To(Equal(1))
+			ref := maintanance.ObjectMeta.GetOwnerReferences()[0]
+			Expect(ref.Name).To(Equal(node.ObjectMeta.Name))
+			Expect(ref.UID).To(Equal(node.ObjectMeta.UID))
+			Expect(ref.APIVersion).To(Equal(node.TypeMeta.APIVersion))
+			Expect(ref.Kind).To(Equal(node.TypeMeta.Kind))
+			hasSetRef = setOwnerRefToNode(maintanance, node)
+			Expect(hasSetRef).To(Equal(false))
+			Expect(len(maintanance.ObjectMeta.GetOwnerReferences())).To(Equal(1))
+		})
 		It("Should not init Node maintenanace if already set", func() {
 			nmCopy := nm.DeepCopy()
 			nmCopy.Status.Phase = nodemaintenanceapi.MaintenanceRunning


### PR DESCRIPTION
CR object must be deleted when node is being deleted. Therefore we need to add an owner ref from CR object to node.

The node ref is BlockOwnerDeletion = false, this requires us to do additional check when deleting the object. This creates the cleanup scenario:  referred to node has been deleted but lease hasn't. 
 (or should we rather add a owner ref from lease object to the node?) Didn't see anyone setting the owner ref of node lease in any usage of leases).