### PR TITLE
fix makefile: phony clause got broken

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,4 +123,4 @@ setupgithook:
 	./hack/precommit-hook.sh setup
 	./hack/commit-msg-hook.sh setup
 
-PHONY: all check fmt test container-build container-push manifests verify-manifests cluster-up cluster-down cluster-sync cluster-functest cluster-clean pull-ci-changes test-courier setupgithook whitespace-commit
+.PHONY: all check fmt test container-build container-push manifests verify-manifests cluster-up cluster-down cluster-sync cluster-functest cluster-clean pull-ci-changes test-courier setupgithook whitespace-commit


### PR DESCRIPTION
last commit damaged the makefiles phony claus. now I fix it back again.

Signed-off-by: Michael Moser <mmoser@redhat.com>