### PR TITLE
Coordinate between different NMO instances

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,4 +123,10 @@ setupgithook:
 	./hack/precommit-hook.sh setup
 	./hack/commit-msg-hook.sh setup
 
-.PHONY: all check fmt test container-build container-push manifests verify-manifests cluster-up cluster-down cluster-sync cluster-functest cluster-clean pull-ci-changes test-courier setupgithook whitespace-commit
+installtest:
+	./hack/test-install.sh
+
+installtestcleanup:
+	./hack/test-install-cleanup.sh
+
+.PHONY: all check fmt test container-build container-push manifests verify-manifests cluster-up cluster-down cluster-sync cluster-functest cluster-clean pull-ci-changes test-courier setupgithook whitespace-commit installtest installtestcleanup

--- a/build/Dockerfile.registry.test
+++ b/build/Dockerfile.registry.test
@@ -1,0 +1,17 @@
+FROM quay.io/openshift/origin-operator-registry:4.2.0
+
+COPY tmp-manifest-install manifests
+
+RUN find manifests/ -name '*'
+
+# Bundle should include only manifests related to the CSV,
+# drop all additional files.
+RUN find manifests/node-maintenance-operator/*/ -type f ! -name '*_crd.*' ! -name '*.clusterserviceversion.*' -exec rm -f {} \;
+
+# Initialize the database
+RUN initializer --manifests manifests/node-maintenance-operator/ --output bundles.db
+
+# There are multiple binaries in the origin-operator-registry
+# We want the registry-server
+ENTRYPOINT ["registry-server"]
+CMD ["--database", "bundles.db"]

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -10,8 +10,8 @@ import (
 	"kubevirt.io/node-maintenance-operator/pkg/apis"
 	"kubevirt.io/node-maintenance-operator/pkg/controller"
 	"kubevirt.io/node-maintenance-operator/pkg/controller/nodemaintenance"
+	"kubevirt.io/node-maintenance-operator/pkg/controller/nodemaintenance/leader"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
-	"github.com/operator-framework/operator-sdk/pkg/leader"
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
 	"github.com/operator-framework/operator-sdk/pkg/metrics"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
@@ -75,7 +75,7 @@ func main() {
 	ctx := context.TODO()
 
 	// Become the leader before proceeding
-	err = leader.Become(ctx, "node-maintenance-operator-lock")
+	err = leader.Become(ctx, "openshift-kni-lifecycle-node-maintenance-operator-lock")
 	if err != nil {
 		log.Error(err, "")
 		os.Exit(1)

--- a/hack/functest.sh
+++ b/hack/functest.sh
@@ -71,3 +71,21 @@ if [[ $VALIDATION_ERRORS != "0" ]]; then
 fi
 
 echo "check validation of openaAPIV3Schema passed"
+
+echo "check coordination of different installations start"
+
+trap "make installtestcleanup" EXIT SIGINT
+
+registry="$IMAGE_REGISTRY"
+if [[ $KUBEVIRT_PROVIDER != "external" ]]; then
+    registry_port=$(docker ps | grep -Po '\d+(?=->5000)')
+    registry=localhost:$registry_port
+
+    export IMAGE_REGISTRY=$registry
+fi
+
+make installtest
+make installtestcleanup
+
+echo "check coordination of different installations passed"
+

--- a/hack/kind-with-registry-stop.sh
+++ b/hack/kind-with-registry-stop.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -ex
+
+export PATH=$PWD/bin:$PWD/operator-registry/bin:$PATH
+
+kind delete cluster
+
+REG=$(docker ps | grep registry:2[[:space:]] | awk '{ print $1 }')
+docker stop $REG
+docker rm $REG
+docker network rm kind
+

--- a/hack/kind-with-registry.sh
+++ b/hack/kind-with-registry.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+set -x
+set -o errexit
+
+# create registry container unless it already exists
+reg_name='kind-registry'
+reg_port='5000'
+running="$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)"
+if [ "${running}" != 'true' ]; then
+  docker run \
+    -d --restart=always -p "${reg_port}:5000" --name "${reg_name}" \
+    registry:2
+fi
+
+# create a cluster with the local registry enabled in containerd
+cat <<EOF | kind create cluster --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+- role: worker
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${reg_port}"]
+    endpoint = ["http://${reg_name}:${reg_port}"]
+EOF
+
+docker network connect "kind" "${reg_name}"
+
+# tell https://tilt.dev to use the registry
+# https://docs.tilt.dev/choosing_clusters.html#discovering-the-registry
+for node in $(kind get nodes); do
+  kubectl annotate node "${node}" "kind.x-k8s.io/registry=localhost:${reg_port}";
+done
+
+echo "*** kind cluster running ***"
+

--- a/hack/test-install-cleanup.sh
+++ b/hack/test-install-cleanup.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -x
+
+OPT=${1:-kind}
+DELOPT=$2
+
+if [[ $OPT != "kind" ]] && [[ $OPT != "minikube" ]]; then
+	echo "error: argument must be either kind or minikube"
+	exit 1
+fi
+
+LOCAL_OLM=olm-repo
+LOCAL_OPREG=operator-registry
+
+setup_utils() {
+	export PATH=$PWD/bin:$PWD/$LOCAL_OPREG/bin:$PATH
+}
+
+stop_cluster() {
+
+	if [[ $OPT == "minikube" ]]; then
+		REG=$(docker ps | grep registry:2[[:space:]] | awk '{ print $1 }')
+		docker stop $REG
+		minikube stop
+		minikube delete
+	fi
+	if [[ $OPT == "kind" ]]; then
+		./hack/kind-with-registry-stop.sh
+	fi
+}
+
+deletefiles() {
+	rm -rf bin
+    rm -rf tmp-manifest-install
+}
+
+setup_utils
+stop_cluster
+
+if [[ $DELOPT == "rm" ]]; then
+	deletefiles
+fi

--- a/hack/test-install.sh
+++ b/hack/test-install.sh
@@ -1,0 +1,290 @@
+#!/bin/bash
+
+set -ex
+
+OPT=${1:-kind}
+USE_OLM_INSTALL=1
+OLM_RELEASE_VERSION="0.15.1"
+LOCAL_OLM=olm-repo
+
+if [[ $OPT != "kind" ]] && [[ $OPT != "minikube" ]]; then
+	echo "error: argument must be either kind or minikube"
+	exit 1
+fi
+
+case "$OPT" in
+	minikube)
+		LOCAL_REGISTRY=localhost.localdomain:5000
+		HOST_IP=$(hostname -I | awk '{ print $1 }')
+		;;
+
+	kind)
+		LOCAL_REGISTRY=localhost:5000
+		;;
+esac
+
+NMOBUNDLE=node-maintenance-operator-bundle
+NMOREG=node-maintenance-operator-registry
+NMO=node-maintenance-operator
+CATALOG_NAMESPACE="olm"
+REGISTRY=quay.io/kubevirt
+
+log_to_file() {
+	exec &> >(tee -a test-install.out)
+}
+
+start_registry() {
+	hreg_name='local-registry'
+	reg_port='5000'
+	running="$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)"
+	if [ "${running}" != 'true' ]; then
+	  docker run \
+		-d --restart=always -p "${reg_port}:5000" --name "${reg_name}" \
+		registry:2
+	fi
+}
+
+setup_src() {
+	if [[ $USE_OLM_INSTALL == "" ]]; then
+		if [[ ! -f $LOCAL_OLM/repo_init ]]; then
+			git clone https://github.com/operator-framework/operator-lifecycle-manager.git $LOCAL_OLM
+			pushd $LOCAL_OLM
+			git checkout origin/release-4.5 -b release-4.5
+			echo "" >repo_init
+			popd
+		fi
+	fi
+}
+
+setup_utils() {
+	mkdir bin || true
+
+	if [[ ! -x bin/kubectl ]]; then
+		curl -L https://storage.googleapis.com/kubernetes-release/release/v1.18.2/bin/linux/amd64/kubectl -o bin/kubectl
+		chmod +x bin/kubectl
+	fi
+	case "$OPT" in
+		kind)
+			if [[ ! -x bin/kind ]]; then
+				curl -sLo bin/kind "$(curl -sL https://api.github.com/repos/kubernetes-sigs/kind/releases/latest | jq -r '[.assets[] | select(.name == "kind-linux-amd64")] | first | .browser_download_url')"
+
+				chmod +x bin/kind
+			fi
+			;;
+		minikube)
+			if [[ ! -x bin/minikube ]]; then
+				curl -Lo ./bin/minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && chmod +x ./bin/minikube
+			fi
+			;;
+	esac
+
+	if [[ ! -x bin/opm ]]; then
+		curl -L https://github.com/operator-framework/operator-registry/releases/download/v1.12.5/linux-amd64-opm -o bin/opm
+		chmod +x bin/opm
+	fi
+
+	if [[ $USE_OLM_INSTALL != "" ]]; then
+		if [[ ! -x bin/install-olm.sh ]]; then
+			curl -L https://github.com/operator-framework/operator-lifecycle-manager/releases/download/${OLM_RELEASE_VERSION}/install.sh -o bin/install-olm.sh
+			chmod +x bin/install-olm.sh
+		fi
+	else
+		pushd $LOCAL_OLM
+		make run-local
+		kubectl get nodes
+		popd
+	fi
+
+	export PATH=$PWD/bin:$PATH
+}
+
+start_cluster() {
+	if [[ $OPT == "kind" ]]; then
+		./hack/kind-with-registry.sh
+		kind export kubeconfig
+	fi
+
+	if [[ $OPT == "minikube" ]]; then
+		minikube start  --insecure-registry="${LOCAL_REGISTRY}"
+		minikube ssh 'sudo bash -c "echo '$HOST_IP' localhost.localdomain >>/etc/hosts"'
+	fi
+
+	if [[ $USE_OLM_INSTALL != "" ]]; then
+        install-olm.sh ${OLM_RELEASE_VERSION}
+    fi
+}
+
+docker_tag() {
+	local from="$1"
+	local to="$2"
+
+	#IMG=$(docker images | grep -F $from' ' | awk '{ print $3 }')
+	IMG=$(docker images --no-trunc --quiet "$from")
+	docker tag $IMG $to
+	docker push $to
+}
+
+make_deployment_def() {
+    local install_img="$1"
+    local OFILE="$2"
+
+	set -ex
+	cp deploy/namespace.yaml ${OFILE}
+	echo -e "\n---\n" >>${OFILE}
+	cat deploy/service_account.yaml >>${OFILE}
+	echo -e "\n---\n" >>${OFILE}
+	cat deploy/role.yaml >>${OFILE}
+	echo -e "\n---\n" >>${OFILE}
+	cat deploy/role_binding.yaml >>${OFILE}
+	echo -e "\n---\n" >>${OFILE}
+	cat deploy/operator.yaml | sed  's#quay.io/kubevirt/node-maintenance-operator:<IMAGE_VERSION>#'${install_img}'#' >>${OFILE}
+	echo -e "\n---\n" >>${OFILE}
+	cat deploy/crds/nodemaintenance_crd.yaml  >>${OFILE}
+}
+
+install_from_deployment() {
+    local OFILE=tmp.yml
+
+    docker_tag $REGISTRY/$NMO $LOCAL_REGISTRY/$NMO
+
+    make_deployment_def	 $LOCAL_REGISTRY/$NMO  "${OFILE}"
+
+    kubectl create -f ${OFILE} --allow-missing-template-keys=true
+
+    kubectl wait --for=condition=available --timeout=600s deployment/node-maintenance-operator -n node-maintenance-operator
+
+    kubectl describe pod -n node-maintenance-operator  | grep Image
+
+}
+
+uninstall_from_deployment() {
+    local OFILE=tmp.yml
+
+    make_deployment_def	 $LOCAL_REGISTRY/$NMO  "${OFILE}"
+
+    kubectl delete -f ${OFILE}
+}
+
+install_with_olm() {
+
+cat <<EOF | kubectl create -f -
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+  labels:
+    kubevirt.io: ""
+  name: node-maintenance-operator2
+EOF
+
+cat <<EOF | kubectl create -f -
+apiVersion: operators.coreos.com/v1alpha2
+kind: OperatorGroup
+metadata:
+  name: node-maintenance-operator
+  namespace: node-maintenance-operator2
+EOF
+
+cat <<EOF | kubectl create -f -
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: node-maintenance-operator
+  namespace: olm
+spec:
+  sourceType: grpc
+  image: quay.io/kubevirt/node-maintenance-operator-registry:v0.6.0
+  displayName: node-maintenance-operator
+  publisher: Red hat
+EOF
+
+cat <<EOF | kubectl create -f -
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: node-maintenance-operator-subscription
+  namespace: node-maintenance-operator2
+spec:
+  channel: beta
+  name: node-maintenance-operator
+  source: node-maintenance-operator
+  sourceNamespace: olm
+  startingCSV: node-maintenance-operator.v0.6.0
+EOF
+
+ retry_count=0
+ while [[ $retry_count -lt 30 ]]; do
+   nmo_pod=$(kubectl get pods -n node-maintenance-operator2 | grep node-maintenance-operator | head -1 | awk '{ print $1 }')
+   if [[ "$nmo_pod" != "" ]]; then
+	  break
+   fi
+   sleep 10s
+   ((retry_count+=1))
+ done
+
+    kubectl wait --for=condition=available --timeout=600s deployment/node-maintenance-operator -n node-maintenance-operator2
+
+    kubectl describe pod -n node-maintenance-operator2  | grep Image
+
+}
+
+#run_bundle() {
+#
+#NMO_NAMESPACE="node-maintenance-operator"
+#REG_IMG=$LOCAL_REGISTRY/$NMOREG:latest
+#
+#opm index add --debug --bundles $LOCAL_REGISTRY/$NMOBUNDLE:latest --tag $REG_IMG -c docker
+#
+#docker_tag $REG_IMG $REG_IMG
+#
+## is it needed anywhere?
+#kubectl create ns ${NMO_NAMESPACE}
+#
+#if [[ $OP == "kind" ]]; then
+#	kind load docker-image ${LOCAL_REGISTRY}/node-maintenance-operator:latest
+#	kind load docker-image ${LOCAL_REGISTRY}/node-maintenance-operator-registry:latest
+#	kind load docker-image ${LOCAL_REGISTRY}/node-maintenance-operator-bundle:latest
+#fi
+#
+#CATALOG_NAMESPACE="${CATALOG_NAMESPACE}" REG_IMG="${REG_IMG}" ./hack/test-olm-make-catalog-source.sh
+#
+#CATALOG_NAMESPACE="${CATALOG_NAMESPACE}" REG_IMG="${REG_IMG}" ./hack/test-olm-make-catalog-source.sh | kubectl create -f -
+#
+#
+#CATALOG_NAMESPACE="${CATALOG_NAMESPACE}" ./hack/test-olm-make-subscription.sh
+#
+#CATALOG_NAMESPACE="${CATALOG_NAMESPACE}" ./hack/test-olm-make-subscription.sh | kubectl create -f -
+#
+#}
+
+log_to_file
+
+create_cr_object() {
+    cat  <<EOF | kubectl create -f -
+apiVersion: nodemaintenance.kubevirt.io/v1beta1
+kind: NodeMaintenance
+metadata:
+  name: nodemaintenance-xyz
+spec:
+  nodeName: kind-worker
+  reason: "Test node maintenance"
+EOF
+ sleep 2
+
+ kubectl logs -n node-maintenance-operator2 $( kubectl get pods -n node-maintenance-operator2 | sed '1d' | awk '{ print $1 }')
+
+ kubectl logs -n node-maintenance-operator $( kubectl get pods -n node-maintenance-operator | sed '1d' | awk '{ print $1 }')
+
+}
+if [[ $OPT == "minikube" ]]; then
+	start_registry
+fi
+setup_src
+setup_utils
+start_cluster
+install_from_deployment
+install_with_olm
+create_cr_object
+
+echo "***  All systems running. liftoff. ***"
+

--- a/pkg/controller/nodemaintenance/leader/leader.go
+++ b/pkg/controller/nodemaintenance/leader/leader.go
@@ -1,0 +1,135 @@
+package leader
+
+import (
+	"context"
+	"time"
+
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+var log = logf.Log.WithName("leader")
+
+// maxBackoffInterval defines the maximum amount of time to wait between
+// attempts to become the leader.
+const maxBackoffInterval = time.Second * 16
+
+//derived from operator sdk function: create the lock object in the global namespace instead of the local one
+func Become(ctx context.Context, lockName string) error {
+	log.Info("Trying to become the leader.")
+
+	ns, err := k8sutil.GetOperatorNamespace()
+	if err != nil {
+		if err == k8sutil.ErrNoNamespace {
+			log.Info("Skipping leader election; not running in a cluster.")
+			return nil
+		}
+		return err
+	}
+
+	config, err := config.GetConfig()
+	if err != nil {
+		return err
+	}
+
+	client, err := crclient.New(config, crclient.Options{})
+	if err != nil {
+		return err
+	}
+
+	owner, err := myOwnerRef(ctx, client, ns)
+	if err != nil {
+		return err
+	}
+
+	// check for existing lock from this pod, in case we got restarted
+	existing := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+		},
+	}
+	//key := crclient.ObjectKey{Namespace: ns, Name: lockName}
+	key := crclient.ObjectKey{Namespace: "default", Name: lockName}
+	err = client.Get(ctx, key, existing)
+
+	switch {
+	case err == nil:
+		for _, existingOwner := range existing.GetOwnerReferences() {
+			if existingOwner.Name == owner.Name {
+				log.Info("Found existing lock with my name. I was likely restarted.")
+				log.Info("Continuing as the leader.")
+				return nil
+			} else {
+				log.Info("Found existing lock", "LockOwner", existingOwner.Name)
+			}
+		}
+	case apierrors.IsNotFound(err):
+		log.Info("No pre-existing lock was found.")
+	default:
+		log.Error(err, "Unknown error trying to get ConfigMap", err)
+		return err
+	}
+
+	cm := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            lockName,
+			Namespace:       "default",
+			OwnerReferences: []metav1.OwnerReference{*owner},
+		},
+	}
+
+	// try to create a lock
+	backoff := time.Second
+	for {
+		err := client.Create(ctx, cm)
+		switch {
+		case err == nil:
+			log.Info("Became the leader.")
+			return nil
+		case apierrors.IsAlreadyExists(err):
+			log.Info("Not the leader. Waiting.")
+			select {
+			case <-time.After(wait.Jitter(backoff, .2)):
+				if backoff < maxBackoffInterval {
+					backoff *= 2
+				}
+				continue
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		default:
+			log.Error(err, "Unknown error creating ConfigMap", err)
+			return err
+		}
+	}
+}
+
+// myOwnerRef returns an OwnerReference that corresponds to the pod in which
+// this code is currently running.
+// It expects the environment variable POD_NAME to be set by the downwards API
+func myOwnerRef(ctx context.Context, client crclient.Client, ns string) (*metav1.OwnerReference, error) {
+	myPod, err := k8sutil.GetPod(ctx, client, ns)
+	if err != nil {
+		return nil, err
+	}
+
+	owner := &metav1.OwnerReference{
+		APIVersion: "v1",
+		Kind:       "Pod",
+		Name:       myPod.ObjectMeta.Name,
+		UID:        myPod.ObjectMeta.UID,
+	}
+	return owner, nil
+}


### PR DESCRIPTION
Need to ensure one active copy of node maint. operator running in different namespaces, this PR adds a variant of leader election that creates a lock object in the default namespace, so that the lock is visible to all instances.

Currently all versions of the operator are treated the same - no mechanisms has been implemented yet that would  allow to handle the more advanced version of the operator with precedence over less advanced versions.

e2e test of the feature were added.

Note that if this solution is accepted then the same leader check must be backported to all relevant versions.

**Release note:**
```release-note 
two installations of NMO in different namespaces may not reconcile the same CR object.
```
