### PR TITLE
Added validation webhook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ fmt: whitespace goimports
 
 .PHONY: goimports
 goimports:
-	go run golang.org/x/tools/cmd/goimports -w ./pkg ./cmd
+	go run golang.org/x/tools/cmd/goimports -w ./pkg ./cmd ./test
 
 .PHONY: whitespace
 whitespace: $(all_sources)
@@ -48,7 +48,7 @@ whitespace: $(all_sources)
 
 .PHONY: vet
 vet: $(cmd_sources) $(pkg_sources)
-	go vet -mod=vendor ./pkg/... ./cmd/...
+	go vet -mod=vendor ./pkg/... ./cmd/... ./test/...
 
 .PHONY: verify-unchanged
 verify-unchanged:

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -167,6 +167,8 @@ func setupWebhookServer(mgr manager.Manager) error {
 
 	server.Register("/validate-nodemaintenance-kubevirt-io-v1beta1-nodemaintenances", admission.ValidatingWebhookFor(&v1beta1.NodeMaintenance{}))
 
+	v1beta1.InitValidator(mgr.GetClient())
+
 	return nil
 
 }

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
 
 	"github.com/spf13/pflag"
@@ -16,6 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"github.com/operator-framework/operator-sdk/pkg/leader"
@@ -24,15 +26,26 @@ import (
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 
 	"kubevirt.io/node-maintenance-operator/pkg/apis"
+	"kubevirt.io/node-maintenance-operator/pkg/apis/nodemaintenance/v1beta1"
 	"kubevirt.io/node-maintenance-operator/pkg/controller"
 	"kubevirt.io/node-maintenance-operator/pkg/controller/nodemaintenance"
 )
 
 // Change below variables to serve metrics on different host or port.
-var (
+const (
 	metricsHost       = "0.0.0.0"
 	metricsPort int32 = 8383
 )
+
+const (
+	// Must match port in deploy/webhooks/nodemaintenance.webhook.yaml
+	WebhookPort = 8443
+	// This is the cert location as configured by OLM
+	WebhookCertDir  = "/apiserver.local.config/certificates"
+	WebhookCertName = "apiserver.crt"
+	WebhookKeyName  = "apiserver.key"
+)
+
 var log = logf.Log.WithName("cmd")
 
 func printVersion() {
@@ -64,9 +77,9 @@ func main() {
 
 	printVersion()
 
-	namespace, err := k8sutil.GetWatchNamespace()
+	namespace, err := k8sutil.GetOperatorNamespace()
 	if err != nil {
-		log.Error(err, "Failed to get watch namespace")
+		log.Error(err, "Failed to get operator's namespace")
 		os.Exit(1)
 	}
 
@@ -90,7 +103,6 @@ func main() {
 
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := manager.New(cfg, manager.Options{
-		Namespace:          namespace,
 		MetricsBindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),
 	})
 	if err != nil {
@@ -121,6 +133,12 @@ func main() {
 		log.Info(err.Error())
 	}
 
+	// Setup webhooks
+	if err := setupWebhookServer(mgr); err != nil {
+		log.Error(err, "Failed to setup webhook server")
+		os.Exit(1)
+	}
+
 	log.Info("Starting the Cmd.")
 
 	// Start the Cmd
@@ -128,4 +146,27 @@ func main() {
 		log.Error(err, "Manager exited non-zero")
 		os.Exit(1)
 	}
+}
+
+func setupWebhookServer(mgr manager.Manager) error {
+
+	// Make sure the certificates are mounted, this should be handled by the OLM
+	certs := []string{filepath.Join(WebhookCertDir, WebhookCertName), filepath.Join(WebhookCertDir, WebhookKeyName)}
+	for _, fname := range certs {
+		if _, err := os.Stat(fname); err != nil {
+			log.Error(err, "Failed to prepare webhook server, certificates not found")
+			return err
+		}
+	}
+
+	server := mgr.GetWebhookServer()
+	server.Port = WebhookPort
+	server.CertDir = WebhookCertDir
+	server.CertName = WebhookCertName
+	server.KeyName = WebhookKeyName
+
+	server.Register("/validate-nodemaintenance-kubevirt-io-v1beta1-nodemaintenances", admission.ValidatingWebhookFor(&v1beta1.NodeMaintenance{}))
+
+	return nil
+
 }

--- a/deploy/olm-catalog/node-maintenance-operator/manifests/node-maintenance-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/node-maintenance-operator/manifests/node-maintenance-operator.clusterserviceversion.yaml
@@ -162,9 +162,9 @@ spec:
                 key: node-role.kubernetes.io/master
     strategy: deployment
   installModes:
-  - supported: true
+  - supported: false
     type: OwnNamespace
-  - supported: true
+  - supported: false
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
@@ -193,3 +193,25 @@ spec:
       alm-owner-kubevirt: nodemaintenanceoperator
       operated-by: nodemaintenanceoperator
   version: 0.7.0
+  webhookdefinitions:
+  - admissionReviewVersions:
+    - v1beta1
+    containerPort: 8443
+    deploymentName: node-maintenance-operator
+    failurePolicy: Fail
+    generateName: nodemaintenance-validation.kubevirt.io
+    rules:
+    - apiGroups:
+      - nodemaintenance.kubevirt.io
+      apiVersions:
+      - v1beta1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - nodemaintenances
+      scope: Cluster
+    sideEffects: None
+    timeoutSeconds: 5
+    type: ValidatingAdmissionWebhook
+    webhookPath: /validate-nodemaintenance-kubevirt-io-v1beta1-nodemaintenances

--- a/deploy/operatorgroup.yaml
+++ b/deploy/operatorgroup.yaml
@@ -3,6 +3,3 @@ kind: OperatorGroup
 metadata:
   name: node-maintenance-operator
   namespace: SUBSCRIPTION_NAMESPACE
-spec:
-  targetNamespaces:
-    - SUBSCRIPTION_NAMESPACE

--- a/deploy/webhooks/nodemaintenance.webhook.yaml
+++ b/deploy/webhooks/nodemaintenance.webhook.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: nodemaintenance-validation.kubevirt.io
+webhooks:
+  - name: nodemaintenance-validation.kubevirt.io
+    clientConfig:
+      service:
+        namespace: placeholder
+        # must match deployment name + "-service"!
+        name: node-maintenance-operator-service
+        port: 8443
+        path: /validate-nodemaintenance-kubevirt-io-v1beta1-nodemaintenances
+    failurePolicy: Fail
+    rules:
+      - apiGroups:
+          - nodemaintenance.kubevirt.io
+        apiVersions:
+          - v1beta1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - nodemaintenances
+        scope: "Cluster"
+    admissionReviewVersions:
+      - v1beta1
+      # - v1 enable this as soon as we vendor a version of controller runtime which understands it
+    sideEffects: None
+    timeoutSeconds: 5

--- a/hack/sync.sh
+++ b/hack/sync.sh
@@ -42,6 +42,10 @@ if [[ $KUBEVIRT_PROVIDER = k8s* ]]; then
 
     OLM_NS=olm
     TARGET_NS=node-maintenance
+
+    # use "latest" olm-operator, containing this fix: https://github.com/operator-framework/operator-lifecycle-manager/issues/1573
+    # TODO remove this as soon as OLM > v0.15.1 is released
+    ./kubevirtci/cluster-up/kubectl.sh patch -n olm deployment olm-operator --patch '{"spec": {"template": {"spec": {"containers": [{"name": "olm-operator","image": "quay.io/operator-framework/olm:latest"}]}}}}'
 fi
 
 registry="$IMAGE_REGISTRY"

--- a/manifests/node-maintenance-operator/template/node-maintenance-operator.clusterserviceversion.yaml
+++ b/manifests/node-maintenance-operator/template/node-maintenance-operator.clusterserviceversion.yaml
@@ -163,9 +163,9 @@ spec:
                 key: node-role.kubernetes.io/master
     strategy: deployment
   installModes:
-  - supported: true
+  - supported: false
     type: OwnNamespace
-  - supported: true
+  - supported: false
     type: SingleNamespace
   - supported: false
     type: MultiNamespace

--- a/manifests/node-maintenance-operator/v0.7.0/manifests/node-maintenance-operator.clusterserviceversion.yaml
+++ b/manifests/node-maintenance-operator/v0.7.0/manifests/node-maintenance-operator.clusterserviceversion.yaml
@@ -162,9 +162,9 @@ spec:
                 key: node-role.kubernetes.io/master
     strategy: deployment
   installModes:
-  - supported: true
+  - supported: false
     type: OwnNamespace
-  - supported: true
+  - supported: false
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
@@ -193,3 +193,25 @@ spec:
       alm-owner-kubevirt: nodemaintenanceoperator
       operated-by: nodemaintenanceoperator
   version: 0.7.0
+  webhookdefinitions:
+  - admissionReviewVersions:
+    - v1beta1
+    containerPort: 8443
+    deploymentName: node-maintenance-operator
+    failurePolicy: Fail
+    generateName: nodemaintenance-validation.kubevirt.io
+    rules:
+    - apiGroups:
+      - nodemaintenance.kubevirt.io
+      apiVersions:
+      - v1beta1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - nodemaintenances
+      scope: Cluster
+    sideEffects: None
+    timeoutSeconds: 5
+    type: ValidatingAdmissionWebhook
+    webhookPath: /validate-nodemaintenance-kubevirt-io-v1beta1-nodemaintenances

--- a/pkg/apis/nodemaintenance/v1beta1/nodemaintenance_api_suite_test.go
+++ b/pkg/apis/nodemaintenance/v1beta1/nodemaintenance_api_suite_test.go
@@ -1,0 +1,13 @@
+package v1beta1
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestNetwork(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Node Maintenance API Suite")
+}

--- a/pkg/apis/nodemaintenance/v1beta1/nodemaintenance_validator.go
+++ b/pkg/apis/nodemaintenance/v1beta1/nodemaintenance_validator.go
@@ -1,0 +1,25 @@
+package v1beta1
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	logger "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+var _ webhook.Validator = &NodeMaintenance{}
+var log = logger.Log.WithName("validator")
+
+func (nm *NodeMaintenance) ValidateCreate() error {
+	log.Info("Validating NodeMaintenance creation", "name", nm.Name)
+	return nil
+}
+
+func (nm *NodeMaintenance) ValidateUpdate(old runtime.Object) error {
+	log.Info("Validating NodeMaintenance update", "name", nm.Name)
+	return nil
+}
+
+func (nm *NodeMaintenance) ValidateDelete() error {
+	log.Info("Validating NodeMaintenance deletion", "name", nm.Name)
+	return nil
+}

--- a/pkg/apis/nodemaintenance/v1beta1/nodemaintenance_validator.go
+++ b/pkg/apis/nodemaintenance/v1beta1/nodemaintenance_validator.go
@@ -66,11 +66,13 @@ func InitValidator(client client.Client) {
 func (v *NodeMaintenanceValidator) ValidateCreate(nm *NodeMaintenance) error {
 	// Validate that node with given name exists
 	if err := v.validateNodeExists(nm.Spec.NodeName); err != nil {
+		log.Info("validation failed", "error", err)
 		return err
 	}
 
 	// Validate that no NodeMaintenance for given node exists yet
 	if err := v.validateNoNodeMaintenanceExists(nm.Spec.NodeName); err != nil {
+		log.Info("validation failed", "error", err)
 		return err
 	}
 
@@ -80,6 +82,7 @@ func (v *NodeMaintenanceValidator) ValidateCreate(nm *NodeMaintenance) error {
 func (v *NodeMaintenanceValidator) ValidateUpdate(new, old *NodeMaintenance) error {
 	// Validate that node name didn't change
 	if new.Spec.NodeName != old.Spec.NodeName {
+		log.Info("validation failed", "error", ErrorNodeNameUpdateForbidden)
 		return fmt.Errorf(ErrorNodeNameUpdateForbidden)
 	}
 	return nil

--- a/pkg/apis/nodemaintenance/v1beta1/nodemaintenance_validator.go
+++ b/pkg/apis/nodemaintenance/v1beta1/nodemaintenance_validator.go
@@ -1,25 +1,106 @@
 package v1beta1
 
 import (
+	"context"
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	logger "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
-var _ webhook.Validator = &NodeMaintenance{}
 var log = logger.Log.WithName("validator")
+
+// introduce a NodeMaintenanceValidator, which gets a k8s client injected
+type NodeMaintenanceValidator struct {
+	client client.Client
+}
+var validator *NodeMaintenanceValidator
+
+// implement webhook.Validator on NodeMaintenance
+var _ webhook.Validator = &NodeMaintenance{}
 
 func (nm *NodeMaintenance) ValidateCreate() error {
 	log.Info("Validating NodeMaintenance creation", "name", nm.Name)
-	return nil
+	if validator == nil {
+		return fmt.Errorf("nodemaintenance validator isn't initialized yet")
+	}
+	return validator.ValidateCreate(nm)
 }
 
 func (nm *NodeMaintenance) ValidateUpdate(old runtime.Object) error {
 	log.Info("Validating NodeMaintenance update", "name", nm.Name)
-	return nil
+	if validator == nil {
+		return fmt.Errorf("nodemaintenance validator isn't initialized yet")
+	}
+	return validator.ValidateUpdate(nm, old.(*NodeMaintenance))
 }
 
 func (nm *NodeMaintenance) ValidateDelete() error {
 	log.Info("Validating NodeMaintenance deletion", "name", nm.Name)
+	if validator == nil {
+		return fmt.Errorf("nodemaintenance validator isn't initialized yet")
+	}
+	return nil
+}
+
+// Initialize the NodeMaintenanceValidator
+func InitValidator(client client.Client) {
+	validator = &NodeMaintenanceValidator{
+		client: client,
+	}
+}
+
+func (v *NodeMaintenanceValidator) ValidateCreate(nm *NodeMaintenance) error {
+	// Validate that node with given name exists
+	if err := v.validateNodeExists(nm.Spec.NodeName); err != nil {
+		return err
+	}
+
+	// Validate that no NodeMaintenance for given node exists yet
+	if err := v.validateNoNodeMaintenanceExists(nm.Spec.NodeName); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (v *NodeMaintenanceValidator) ValidateUpdate(new, old *NodeMaintenance) error {
+	// Validate that node name didn't change
+	if new.Spec.NodeName != old.Spec.NodeName {
+		return fmt.Errorf("updating spec.NodeName isn't allowed")
+	}
+	return nil
+}
+
+func (v *NodeMaintenanceValidator) validateNodeExists(nodeName string) error {
+	var node v1.Node
+	key := types.NamespacedName{
+		Name: nodeName,
+	}
+	if err := v.client.Get(context.TODO(), key, &node); err != nil {
+		if apierrors.IsNotFound(err) {
+			return fmt.Errorf("invalid nodeName, no node with name %s found", nodeName)
+		}
+		return fmt.Errorf("could not get node for validating spec.NodeName, please try again: %v", err)
+	}
+	return nil
+}
+
+func (v *NodeMaintenanceValidator) validateNoNodeMaintenanceExists(nodeName string) error {
+	var nodeMaintenances NodeMaintenanceList
+	if err := v.client.List(context.TODO(), &nodeMaintenances, &client.ListOptions{}); err != nil {
+		return fmt.Errorf("could not list NodeMaintenances for validating spec.NodeName, please try again: %v", err)
+	}
+
+	for _, nm := range nodeMaintenances.Items {
+		if nm.Spec.NodeName == nodeName {
+			return fmt.Errorf("invalid nodeName, a NodeMaintenance for node %s already exists", nodeName)
+		}
+	}
 	return nil
 }

--- a/pkg/apis/nodemaintenance/v1beta1/nodemaintenance_validator_test.go
+++ b/pkg/apis/nodemaintenance/v1beta1/nodemaintenance_validator_test.go
@@ -1,0 +1,105 @@
+package v1beta1
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("NodeMaintenance Validation", func() {
+
+	const nonExistingNodeName = "node-not-exists"
+	const existingNodeName = "node-exists"
+
+	var (
+		client  client.Client
+		objects = make([]runtime.Object, 0)
+	)
+
+	JustBeforeEach(func() {
+		scheme := runtime.NewScheme()
+		// add our own scheme
+		SchemeBuilder.AddToScheme(scheme)
+		// add more schemes
+		v1.AddToScheme(scheme)
+
+		client = fake.NewFakeClientWithScheme(scheme, objects...)
+		InitValidator(client)
+	})
+
+	Context("creating NodeMaintenance", func() {
+
+		Context("for not existing node", func() {
+
+			It("should be rejected", func() {
+				nm := &NodeMaintenance{
+					Spec: NodeMaintenanceSpec{
+						NodeName: nonExistingNodeName,
+					},
+				}
+				err := nm.ValidateCreate()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring(ErrorNodeNotExists, nonExistingNodeName))
+			})
+
+		})
+
+		Context("for node already in maintenance", func() {
+
+			BeforeEach(func() {
+				// add a node and node maintenance CR to fake client
+				node := &v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: existingNodeName,
+					},
+				}
+				nmExisting := &NodeMaintenance{
+					Spec: NodeMaintenanceSpec{
+						NodeName: existingNodeName,
+					},
+				}
+				objects = append(objects, node, nmExisting)
+			})
+
+			It("should be rejected", func() {
+				nm := NodeMaintenance{
+					Spec: NodeMaintenanceSpec{
+						NodeName: existingNodeName,
+					},
+				}
+				err := nm.ValidateCreate()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring(ErrorNodeMaintenanceExists, existingNodeName))
+			})
+
+		})
+	})
+
+	Context("updating NodeMaintenance", func() {
+
+		Context("with new nodeName", func() {
+
+			It("should be rejected", func() {
+				nmOld := NodeMaintenance{
+					Spec: NodeMaintenanceSpec{
+						NodeName: existingNodeName,
+					},
+				}
+				nm := NodeMaintenance{
+					Spec: NodeMaintenanceSpec{
+						NodeName: "newNodeName",
+					},
+				}
+				err := nm.ValidateUpdate(&nmOld)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring(ErrorNodeNameUpdateForbidden))
+			})
+
+		})
+	})
+})

--- a/test/e2e/nodemaintenance_test.go
+++ b/test/e2e/nodemaintenance_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"k8s.io/utils/pointer"
 	"os"
 	"reflect"
 	"strings"
@@ -21,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	operator "kubevirt.io/node-maintenance-operator/pkg/apis/nodemaintenance/v1beta1"
@@ -86,7 +86,7 @@ func showDeploymentStatus(t *testing.T, callerError error) {
 	}
 }
 
-func  checkValidLease(t *testing.T, nodeName string) error {
+func checkValidLease(t *testing.T, nodeName string) error {
 
 	// FIXME this won't work: nmo.LeaseNamespace is overwritten by the operator during runtime, and we will never see that here...
 	nName := types.NamespacedName{Namespace: nmo.LeaseNamespace, Name: nodeName}
@@ -103,25 +103,25 @@ func  checkValidLease(t *testing.T, nodeName string) error {
 		return fmt.Errorf("checkValidLease wrong Spec.HolderIdentity")
 	}
 
-	if lease.Spec.RenewTime == nil  {
+	if lease.Spec.RenewTime == nil {
 		return fmt.Errorf("checkValidLease nil RenewTime")
 	}
 
 	timeNow := time.Now()
-	if  (*lease.Spec.RenewTime).Time.After(timeNow)  {
+	if (*lease.Spec.RenewTime).Time.After(timeNow) {
 		return fmt.Errorf("checkValidLease RenewTime in the future current time %s renew time %s", timeNow.Format(time.UnixDate), (*lease.Spec.RenewTime).Format(time.UnixDate))
 
 	}
 	tm := (*lease.Spec.RenewTime).Time
-	tm = tm.Add( time.Duration(int64(*lease.Spec.LeaseDurationSeconds) * int64(time.Second))  )
-	if  tm.Before(timeNow) {
+	tm = tm.Add(time.Duration(int64(*lease.Spec.LeaseDurationSeconds) * int64(time.Second)))
+	if tm.Before(timeNow) {
 		return fmt.Errorf("checkValidLease expiration time in the past time Now: %s expiration time %s :: leaseDuration %d renew time %s", timeNow.Format(time.UnixDate), tm.Format(time.UnixDate), *lease.Spec.LeaseDurationSeconds, (*lease.Spec.RenewTime).Time.Format(time.UnixDate))
 	}
 
 	return nil
 }
 
-func  checkInvalidLease(t *testing.T, nodeName string) error {
+func checkInvalidLease(t *testing.T, nodeName string) error {
 	nName := types.NamespacedName{Namespace: nmo.LeaseNamespace, Name: nodeName}
 	lease := &coordv1beta1.Lease{}
 	err := Client.Get(context.TODO(), nName, lease)
@@ -129,10 +129,10 @@ func  checkInvalidLease(t *testing.T, nodeName string) error {
 		return fmt.Errorf("can't get lease node %s : %v", nodeName, err)
 	}
 
-	if lease.Spec.AcquireTime != nil  {
+	if lease.Spec.AcquireTime != nil {
 		return fmt.Errorf("AcquireTime not nil %s", nodeName)
 	}
-	if lease.Spec.LeaseDurationSeconds  != nil {
+	if lease.Spec.LeaseDurationSeconds != nil {
 		return fmt.Errorf("LeaseDurationSeconds not nil %s", nodeName)
 	}
 	if lease.Spec.RenewTime != nil {
@@ -271,7 +271,7 @@ func enterAndExitMaintenanceMode(t *testing.T) error {
 	// Wait for operator log showing it reconciles with fixed duration
 	// caused by drain, caused by termination graceperiod > drain timeout
 	t.Log("Waiting for drain timeout log")
-	if err = wait.PollImmediate(5*time.Second, 2*time.Minute, func()(bool, error) {
+	if err = wait.PollImmediate(5*time.Second, 2*time.Minute, func() (bool, error) {
 		logs := getOperatorLogs(t)
 		if strings.Contains(logs, nmo.FixedDurationReconcileLog) {
 			return true, nil
@@ -363,7 +363,7 @@ func enterAndExitMaintenanceMode(t *testing.T) error {
 	}
 
 	if kubevirtTaintExist(node) {
-		showDeploymentStatus(t, fmt.Errorf("Node %s kubevirt.io/drain:NoSchedule taint should have been removed", nodeName) )
+		showDeploymentStatus(t, fmt.Errorf("Node %s kubevirt.io/drain:NoSchedule taint should have been removed", nodeName))
 	}
 
 	err = checkInvalidLease(t, nodeName)
@@ -414,14 +414,15 @@ func deleteSimpleDeployment(t *testing.T, namespace string) error {
 
 	return wait.PollImmediate(1*time.Second, 20*time.Second, func() (bool, error) {
 
-				err = Client.Get(context.TODO(), namespaceName, deploymentToDelete)
-				if err != nil {
-					if errors.IsNotFound(err) {
-						return true, nil
-					}
-					return false, fmt.Errorf("error encountered during deletion of deployment: %v", err)
-				}
-				return false, nil
+		err = Client.Get(context.TODO(), namespaceName, deploymentToDelete)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, fmt.Errorf("error encountered during deletion of deployment: %v", err)
+		}
+		return false, nil
+
 	})
 }
 
@@ -470,7 +471,7 @@ func createSimpleDeployment(t *testing.T, namespace string, nodeName string) err
 					}},
 					NodeSelector: map[string]string{"kubernetes.io/hostname": nodeName},
 					// make sure we run into the drain timeout at least once
-					TerminationGracePeriodSeconds: pointer.Int64Ptr(int64(nmo.DrainerTimeout.Seconds()) +10),
+					TerminationGracePeriodSeconds: pointer.Int64Ptr(int64(nmo.DrainerTimeout.Seconds()) + 10),
 				},
 			},
 		},
@@ -550,7 +551,7 @@ func checkFailureStatus(t *testing.T) {
 		} else {
 			if len(pods.Items) != 0 && pods.Items[0].Name != nm.Status.PendingPods[0] {
 				t.Logf("Status.PendingPods on %s nodeMaintenance does not contain pod %s", nm.Name, pods.Items[0].Name)
-			} else  {
+			} else {
 				t.Logf("no deployment pods found")
 			}
 		}
@@ -581,4 +582,3 @@ func waitForDeployment(t *testing.T, namespace, name string, replicas int, retry
 	t.Logf("Deployment available (%d/%d)\n", replicas, replicas)
 	return nil
 }
-


### PR DESCRIPTION
For validation of CRs during creation and updates we need a validation webhook.

Replaces #84 
Fixes #97 
Fixes #58 

Validations implemented in this PR are:
- on creation:
  - validate nodename, a node with that name has to exist
  - prevent multiple CRs for the same node
- on update:
  - prevent nodename change

Interesting implementation details:
- Added `deploy/webhooks/nodemaintenancd.webhook.yaml`, will be added to CSVs by `make generate-bundle`
- Restrict `installMode` to `AllNamespaces` only, and modified `OperatorGroup` accordingly. Otherwise OLM will restrict webhook calls to CRs in namespaces of the OperatorGroup, which doesn't work for cluster scoped CRDs.
- Added code for serving the webhook
- Workaround for OLM installation: patch olm-operator to `latest` image because of unreleased bugfix
- Added ctual validation code
- Added unit and e2e test

```release-note
Added webhook for nodename validation
```