### PR TITLE
Added master quorum validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ export TARGETCOVERAGE=60
 
 KUBEVIRTCI_PATH=$$(pwd)/kubevirtci/cluster-up
 KUBEVIRTCI_CONFIG_PATH=$$(pwd)/_ci-configs
+export KUBEVIRT_NUM_NODES ?= 3
 
 export GINKGO ?= build/_output/bin/ginkgo
 
@@ -135,7 +136,7 @@ verify-manifests:
 
 .PHONY: cluster-up
 cluster-up:
-	KUBEVIRT_NUM_NODES=2 $(KUBEVIRTCI_PATH)/up.sh
+	$(KUBEVIRTCI_PATH)/up.sh
 
 .PHONY: cluster-down
 cluster-down:

--- a/deploy/olm-catalog/node-maintenance-operator/manifests/node-maintenance-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/node-maintenance-operator/manifests/node-maintenance-operator.clusterserviceversion.yaml
@@ -62,6 +62,14 @@ spec:
           - watch
           - create
         - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - ""
           resources:
           - nodes
@@ -212,6 +220,6 @@ spec:
       - nodemaintenances
       scope: Cluster
     sideEffects: None
-    timeoutSeconds: 5
+    timeoutSeconds: 15
     type: ValidatingAdmissionWebhook
     webhookPath: /validate-nodemaintenance-kubevirt-io-v1beta1-nodemaintenances

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -27,6 +27,14 @@ rules:
   - watch
   - create
 - apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - nodes

--- a/deploy/webhooks/nodemaintenance.webhook.yaml
+++ b/deploy/webhooks/nodemaintenance.webhook.yaml
@@ -28,4 +28,4 @@ webhooks:
       - v1beta1
       # - v1 enable this as soon as we vendor a version of controller runtime which understands it
     sideEffects: None
-    timeoutSeconds: 5
+    timeoutSeconds: 15

--- a/hack/functest.sh
+++ b/hack/functest.sh
@@ -21,6 +21,14 @@ if [[ $KUBEVIRT_PROVIDER != "external" ]]; then
     export KUBECONFIG=$(${KUBEVIRTCI_PATH}/kubeconfig.sh)
 fi
 
+if [[ $KUBEVIRT_PROVIDER = k8s* ]]; then
+    # on k8s we don' t have a etcd-quorum-guard running
+    # we need it for testing the master quorum validation
+    # so we create a fake etcd-quorum-guard PDB with maxUnavailable = 0, which will always result in disruptionsAllowed = 0 without a corresponding deployment
+    # that will make node maintenance requests for master nodes always fail
+    $KUBECTL_CMD apply -f test/manifests/fake-etcd-quorum-guard.yaml
+fi
+
 # let's track errors on our own here for being able to write a nice comment afterwards
 set +e
 # FIXME use a different namespace for test deployments, and create / destroy it before / after test execution

--- a/hack/functest.sh
+++ b/hack/functest.sh
@@ -16,16 +16,6 @@ fi
 
 KUBECTL_CMD="${KUBEVIRTCI_PATH}/kubectl.sh"
 
-function new_test() {
-    name=$1
-
-    printf "%0.s=" {1..80}
-    echo
-    echo ${name}
-}
-
-new_test 'Test e2e Node Mainenance'
-
 # Run tests
 if [[ $KUBEVIRT_PROVIDER != "external" ]]; then
     export KUBECONFIG=$(${KUBEVIRTCI_PATH}/kubeconfig.sh)

--- a/hack/get-opm.sh
+++ b/hack/get-opm.sh
@@ -14,7 +14,7 @@ if [[ ! -x $CURRENT_OPM ]]; then
     set -e
 fi
 
-DETECTED_OPM_VERSION=$($CURRENT_OPM version | sed -r 's/^.*OpmVersion:"([0-9.]+)".*$/\1/g')
+DETECTED_OPM_VERSION=v$($CURRENT_OPM version | sed -r 's/^.*OpmVersion:"([0-9.]+)".*$/\1/g')
 
 function check_need_upgrade() {
     local detectedversion="$2"

--- a/manifests/node-maintenance-operator/v0.7.0/manifests/node-maintenance-operator.clusterserviceversion.yaml
+++ b/manifests/node-maintenance-operator/v0.7.0/manifests/node-maintenance-operator.clusterserviceversion.yaml
@@ -62,6 +62,14 @@ spec:
           - watch
           - create
         - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - ""
           resources:
           - nodes
@@ -212,6 +220,6 @@ spec:
       - nodemaintenances
       scope: Cluster
     sideEffects: None
-    timeoutSeconds: 5
+    timeoutSeconds: 15
     type: ValidatingAdmissionWebhook
     webhookPath: /validate-nodemaintenance-kubevirt-io-v1beta1-nodemaintenances

--- a/pkg/apis/nodemaintenance/v1beta1/nodemaintenance_validator_test.go
+++ b/pkg/apis/nodemaintenance/v1beta1/nodemaintenance_validator_test.go
@@ -5,6 +5,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -18,8 +19,12 @@ var _ = Describe("NodeMaintenance Validation", func() {
 
 	var (
 		client  client.Client
-		objects = make([]runtime.Object, 0)
+		objects []runtime.Object
 	)
+
+	BeforeEach(func() {
+		objects = make([]runtime.Object, 0)
+	})
 
 	JustBeforeEach(func() {
 		scheme := runtime.NewScheme()
@@ -27,21 +32,18 @@ var _ = Describe("NodeMaintenance Validation", func() {
 		SchemeBuilder.AddToScheme(scheme)
 		// add more schemes
 		v1.AddToScheme(scheme)
+		v1beta1.AddToScheme(scheme)
 
 		client = fake.NewFakeClientWithScheme(scheme, objects...)
 		InitValidator(client)
 	})
 
-	Context("creating NodeMaintenance", func() {
+	Describe("creating NodeMaintenance", func() {
 
 		Context("for not existing node", func() {
 
 			It("should be rejected", func() {
-				nm := &NodeMaintenance{
-					Spec: NodeMaintenanceSpec{
-						NodeName: nonExistingNodeName,
-					},
-				}
+				nm := getTestNMO(nonExistingNodeName)
 				err := nm.ValidateCreate()
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring(ErrorNodeNotExists, nonExistingNodeName))
@@ -53,49 +55,79 @@ var _ = Describe("NodeMaintenance Validation", func() {
 
 			BeforeEach(func() {
 				// add a node and node maintenance CR to fake client
-				node := &v1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: existingNodeName,
-					},
-				}
-				nmExisting := &NodeMaintenance{
-					Spec: NodeMaintenanceSpec{
-						NodeName: existingNodeName,
-					},
-				}
+				node := getTestNode(existingNodeName, false)
+				nmExisting := getTestNMO(existingNodeName)
 				objects = append(objects, node, nmExisting)
 			})
 
 			It("should be rejected", func() {
-				nm := NodeMaintenance{
-					Spec: NodeMaintenanceSpec{
-						NodeName: existingNodeName,
-					},
-				}
+				nm := getTestNMO(existingNodeName)
 				err := nm.ValidateCreate()
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring(ErrorNodeMaintenanceExists, existingNodeName))
 			})
 
 		})
+
+		Context("for master node", func() {
+
+			BeforeEach(func() {
+				node := getTestNode(existingNodeName, true)
+				objects = append(objects, node)
+			})
+
+			Context("with potential quorum violation", func() {
+
+				BeforeEach(func() {
+					pdb := getTestPDB(0)
+					objects = append(objects, pdb)
+				})
+
+				It("should be rejected", func() {
+					nm := getTestNMO(existingNodeName)
+					err := nm.ValidateCreate()
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring(ErrorMasterQuorumViolation))
+				})
+
+			})
+
+			Context("without potential quorum violation", func() {
+
+				BeforeEach(func() {
+					pdb := getTestPDB(1)
+					objects = append(objects, pdb)
+				})
+
+				It("should not be rejected", func() {
+					nm := getTestNMO(existingNodeName)
+					err := nm.ValidateCreate()
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+			})
+
+			Context("without etcd quorum guard PDB", func() {
+
+				It("should not be rejected", func() {
+					nm := getTestNMO(existingNodeName)
+					err := nm.ValidateCreate()
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+			})
+		})
+
 	})
 
-	Context("updating NodeMaintenance", func() {
+	Describe("updating NodeMaintenance", func() {
 
 		Context("with new nodeName", func() {
 
 			It("should be rejected", func() {
-				nmOld := NodeMaintenance{
-					Spec: NodeMaintenanceSpec{
-						NodeName: existingNodeName,
-					},
-				}
-				nm := NodeMaintenance{
-					Spec: NodeMaintenanceSpec{
-						NodeName: "newNodeName",
-					},
-				}
-				err := nm.ValidateUpdate(&nmOld)
+				nmOld := getTestNMO(existingNodeName)
+				nm := getTestNMO("newNodeName")
+				err := nm.ValidateUpdate(nmOld)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring(ErrorNodeNameUpdateForbidden))
 			})
@@ -103,3 +135,37 @@ var _ = Describe("NodeMaintenance Validation", func() {
 		})
 	})
 })
+
+func getTestNMO(nodeName string) *NodeMaintenance {
+	return &NodeMaintenance{
+		Spec: NodeMaintenanceSpec{
+			NodeName: nodeName,
+		},
+	}
+}
+
+func getTestNode(name string, isMaster bool) *v1.Node {
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+	if isMaster {
+		node.ObjectMeta.Labels = map[string]string{
+			LabelNameRoleMaster: "",
+		}
+	}
+	return node
+}
+
+func getTestPDB(allowed int) *v1beta1.PodDisruptionBudget {
+	return &v1beta1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: EtcdQuorumPDBNamespace,
+			Name:      EtcdQuorumPDBName,
+		},
+		Status: v1beta1.PodDisruptionBudgetStatus{
+			DisruptionsAllowed: int32(allowed),
+		},
+	}
+}

--- a/test/e2e/nodemaintenance_test.go
+++ b/test/e2e/nodemaintenance_test.go
@@ -145,24 +145,25 @@ func checkInvalidLease(t *testing.T, nodeName string) error {
 	return nil
 }
 
-func countNodes(t *testing.T) (int, string, error) {
+func getNodes(t *testing.T) ([]string, []string, error) {
+	masters := make([]string, 0)
+	workers := make([]string, 0)
+
 	nodesList := &corev1.NodeList{}
 	err := Client.List(context.TODO(), nodesList, &client.ListOptions{})
 	if err != nil {
 		showDeploymentStatus(t, fmt.Errorf("Failed to list nodes %v", err))
-		return -1, "", err
+		return masters, workers, err
 	}
-
-	computeNodesNumber := 0
-	workerNodeName := ""
 
 	for _, node := range nodesList.Items {
-		if _, exists := node.Labels["node-role.kubernetes.io/master"]; !exists {
-			computeNodesNumber++
-			workerNodeName = node.ObjectMeta.Name
+		if _, exists := node.Labels["node-role.kubernetes.io/master"]; exists {
+			masters = append(masters, node.Name)
+		} else {
+			workers = append(workers, node.Name)
 		}
 	}
-	return computeNodesNumber, workerNodeName, nil
+	return masters, workers, nil
 }
 
 func enterAndExitMaintenanceMode(t *testing.T) error {
@@ -171,17 +172,23 @@ func enterAndExitMaintenanceMode(t *testing.T) error {
 		return fmt.Errorf("could not get namespace")
 	}
 
-	computeNodesNumber, workerNodeName, err := countNodes(t)
+	masters, workers, err := getNodes(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(masters) == 0 {
+		t.Fatal(fmt.Errorf("no master nodes found"))
+	}
+	if len(workers) == 0 {
+		t.Fatal(fmt.Errorf("no worker nodes found"))
+	}
+
+	err = createSimpleDeployment(t, namespace)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = createSimpleDeployment(t, namespace, workerNodeName)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	nodeName, err := getCurrentDeploymentHostName(t)
+	maintenanceNodeName, err := getCurrentDeploymentNodeName(t)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -209,8 +216,8 @@ func enterAndExitMaintenanceMode(t *testing.T) error {
 		t.Errorf("FAIL: CR creation for not existing node has been rejected with unexpected error message: %s", err.Error())
 	}
 
-	t.Logf("Putting node %s into maintanance", nodeName)
-	nodeMaintenance.Spec.NodeName = nodeName
+	t.Logf("Putting node %s into maintanance", maintenanceNodeName)
+	nodeMaintenance.Spec.NodeName = maintenanceNodeName
 	err = Client.Create(context.TODO(), nodeMaintenance)
 	if err != nil {
 		t.Fatalf("Can't create CR: %v", err)
@@ -225,7 +232,7 @@ func enterAndExitMaintenanceMode(t *testing.T) error {
 	} else if !strings.Contains(err.Error(), fmt.Sprintf(operator.ErrorNodeNameUpdateForbidden)) {
 		t.Errorf("FAIL: CR update with new NodeName has been rejected with unexpected error message: %s", err.Error())
 	}
-	nodeMaintenance.Spec.NodeName = nodeName
+	nodeMaintenance.Spec.NodeName = maintenanceNodeName
 
 	t.Logf("Validation test: create NM for same node")
 	nmNew = &operator.NodeMaintenance{
@@ -237,14 +244,14 @@ func enterAndExitMaintenanceMode(t *testing.T) error {
 			Name: "nodemaintenance-new",
 		},
 		Spec: operator.NodeMaintenanceSpec{
-			NodeName: nodeName,
+			NodeName: maintenanceNodeName,
 			Reason:   "Test duplicate maintenance",
 		},
 	}
 	err = Client.Create(context.TODO(), nmNew)
 	if err == nil {
 		t.Errorf("FAIL: CR for node already in maintenance should have been rejected: %v", err)
-	} else if !strings.Contains(err.Error(), fmt.Sprintf(operator.ErrorNodeMaintenanceExists, nodeName)) {
+	} else if !strings.Contains(err.Error(), fmt.Sprintf(operator.ErrorNodeMaintenanceExists, maintenanceNodeName)) {
 		t.Errorf("FAIL: CR creation for node already in maintenance has been rejected with unexpected error message: %s", err.Error())
 	}
 
@@ -299,43 +306,44 @@ func enterAndExitMaintenanceMode(t *testing.T) error {
 	}
 
 	node := &corev1.Node{}
-	err = Client.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: nodeName}, node)
+	err = Client.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: maintenanceNodeName}, node)
 	if err != nil {
 		showDeploymentStatus(t, fmt.Errorf("Failed to get CRD after entering main. mode : %v", err))
 	}
 
 	if node.Spec.Unschedulable == false {
 		checkFailureStatus(t)
-		showDeploymentStatus(t, fmt.Errorf("Node %s should have been unschedulable ", nodeName))
+		showDeploymentStatus(t, fmt.Errorf("Node %s should have been unschedulable ", maintenanceNodeName))
 	}
 
 	if !kubevirtTaintExist(node) {
 		checkFailureStatus(t)
-		showDeploymentStatus(t, fmt.Errorf("Node %s should have been tainted with kubevirt.io/drain:NoSchedule", nodeName))
+		showDeploymentStatus(t, fmt.Errorf("Node %s should have been tainted with kubevirt.io/drain:NoSchedule", maintenanceNodeName))
 	}
 
-	err = checkValidLease(t, nodeName)
+	err = checkValidLease(t, maintenanceNodeName)
 	if err != nil {
 		showDeploymentStatus(t, fmt.Errorf("no valid lease after nmo completion: %v", err))
 	}
 
-	if computeNodesNumber > 2 {
-		err = waitForDeployment(t, namespace, testDeployment, 1, retryInterval, timeout)
+	// if we have 2 workers or more, check the pod was moved to another node
+	if len(workers) >= 2 {
+		err = waitForDeployment(t, namespace, testDeployment, retryInterval, timeout)
 		if err != nil {
 			showDeploymentStatus(t, fmt.Errorf("failed to wait for deployment. error %v", err))
 		}
 
-		newNodeName, err := getCurrentDeploymentHostName(t)
+		newNodeName, err := getCurrentDeploymentNodeName(t)
 		if err != nil {
 			showDeploymentStatus(t, err)
 		}
 
-		if newNodeName == nodeName {
-			showDeploymentStatus(t, fmt.Errorf("Deployment was done on node %s that should be under maintanence", nodeName))
+		if newNodeName == maintenanceNodeName {
+			showDeploymentStatus(t, fmt.Errorf("Deployment was done on node %s that should be under maintanence", maintenanceNodeName))
 		}
 	}
 
-	t.Logf("Setting node %s out of maintanance", nodeName)
+	t.Logf("Setting node %s out of maintanance", maintenanceNodeName)
 
 	nodeMaintenanceDelete := &operator.NodeMaintenance{}
 
@@ -353,29 +361,29 @@ func enterAndExitMaintenanceMode(t *testing.T) error {
 	time.Sleep(60 * time.Second)
 
 	node = &corev1.Node{}
-	err = Client.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: nodeName}, node)
+	err = Client.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: maintenanceNodeName}, node)
 	if err != nil {
 		showDeploymentStatus(t, fmt.Errorf("can't get CRD. error %v", err))
 	}
 
 	if node.Spec.Unschedulable == true {
-		showDeploymentStatus(t, fmt.Errorf("Node %s should have been schedulable", nodeName))
+		showDeploymentStatus(t, fmt.Errorf("Node %s should have been schedulable", maintenanceNodeName))
 	}
 
 	if kubevirtTaintExist(node) {
-		showDeploymentStatus(t, fmt.Errorf("Node %s kubevirt.io/drain:NoSchedule taint should have been removed", nodeName))
+		showDeploymentStatus(t, fmt.Errorf("Node %s kubevirt.io/drain:NoSchedule taint should have been removed", maintenanceNodeName))
 	}
 
-	err = checkInvalidLease(t, nodeName)
+	err = checkInvalidLease(t, maintenanceNodeName)
 	if err != nil {
 		showDeploymentStatus(t, fmt.Errorf("valid lease after nmo completion %v", err))
 	}
 
 	// Check that the deployment has 1 replica running after maintenance is removed.
 	t.Logf("%s: wait for deployment.", time.Now().Format("2006-01-02 15:04:05.000000"))
-	err = waitForDeployment(t, namespace, testDeployment, 1, retryInterval, timeout)
+	err = waitForDeployment(t, namespace, testDeployment, retryInterval, timeout)
 	if err != nil {
-		showDeploymentStatus(t, fmt.Errorf("%s: failed to wait for deployment. error %v.", err, time.Now().Format("2006-01-02 15:04:05.000000")))
+		showDeploymentStatus(t, fmt.Errorf("failed to wait for deployment: %v", err))
 	}
 
 	err = deleteSimpleDeployment(t, namespace)
@@ -383,6 +391,10 @@ func enterAndExitMaintenanceMode(t *testing.T) error {
 		t.Fatal(err)
 	}
 	t.Logf("test deployment deleted")
+
+	if t.Failed() {
+		showDeploymentStatus(t, fmt.Errorf("some test(s) failed"))
+	}
 
 	return nil
 }
@@ -426,7 +438,7 @@ func deleteSimpleDeployment(t *testing.T, namespace string) error {
 	})
 }
 
-func createSimpleDeployment(t *testing.T, namespace string, nodeName string) error {
+func createSimpleDeployment(t *testing.T, namespace string) error {
 	dep := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps/v1",
@@ -454,7 +466,7 @@ func createSimpleDeployment(t *testing.T, namespace string, nodeName string) err
 									{
 										MatchExpressions: []corev1.NodeSelectorRequirement{
 											{
-												Key:      "node-role.kubernetes.io/" + nodeName,
+												Key:      "node-role.kubernetes.io/master",
 												Operator: corev1.NodeSelectorOpDoesNotExist,
 											},
 										},
@@ -469,7 +481,6 @@ func createSimpleDeployment(t *testing.T, namespace string, nodeName string) err
 						Command: []string{"/bin/sh"},
 						Args:    []string{"-c", "while true; do echo hello; sleep 10;done"},
 					}},
-					NodeSelector: map[string]string{"kubernetes.io/hostname": nodeName},
 					// make sure we run into the drain timeout at least once
 					TerminationGracePeriodSeconds: pointer.Int64Ptr(int64(nmo.DrainerTimeout.Seconds()) + 10),
 				},
@@ -483,7 +494,7 @@ func createSimpleDeployment(t *testing.T, namespace string, nodeName string) err
 		return err
 	}
 	// wait for testPodDeployment to reach 1 replicas
-	err = waitForDeployment(t, namespace, testDeployment, 1, retryInterval, timeout)
+	err = waitForDeployment(t, namespace, testDeployment, retryInterval, timeout)
 	if err != nil {
 		return err
 	}
@@ -505,7 +516,7 @@ func getCurrentDeploymentPods(t *testing.T) (*corev1.PodList, error) {
 	return pods, nil
 }
 
-func getCurrentDeploymentHostName(t *testing.T) (string, error) {
+func getCurrentDeploymentNodeName(t *testing.T) (string, error) {
 	pods, err := getCurrentDeploymentPods(t)
 	if err != nil {
 		return "", err
@@ -558,7 +569,7 @@ func checkFailureStatus(t *testing.T) {
 	}
 }
 
-func waitForDeployment(t *testing.T, namespace, name string, replicas int, retryInterval, timeout time.Duration) error {
+func waitForDeployment(t *testing.T, namespace, name string, retryInterval, timeout time.Duration) error {
 	err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
 		deployment, err := KubeClient.AppsV1().Deployments(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 		if err != nil {
@@ -569,16 +580,16 @@ func waitForDeployment(t *testing.T, namespace, name string, replicas int, retry
 			return false, err
 		}
 
-		if int(deployment.Status.AvailableReplicas) >= replicas {
+		if int(deployment.Status.AvailableReplicas) >= 1 {
 			return true, nil
 		}
 		t.Logf("Waiting for full availability of %s deployment (%d/%d)\n", name,
-			deployment.Status.AvailableReplicas, replicas)
+			deployment.Status.AvailableReplicas, 1)
 		return false, nil
 	})
 	if err != nil {
 		return err
 	}
-	t.Logf("Deployment available (%d/%d)\n", replicas, replicas)
+	t.Logf("Deployment available (%d/%d)\n", 1, 1)
 	return nil
 }

--- a/test/manifests/fake-etcd-quorum-guard.yaml
+++ b/test/manifests/fake-etcd-quorum-guard.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-machine-config-operator
+  labels:
+    name: openshift-machine-config-operator
+---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  namespace: openshift-machine-config-operator
+  name: etcd-quorum-guard
+spec:
+  maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: fake-etcd-quorum-guard


### PR DESCRIPTION
For the master quorum validation we check the PodDisruptionBudget of the etcd-quorum-guard. When it allows disruptions, we can
put a master node into maintenance.

This works on Openshift only, on k8s clusters (not having the etcd-quorum-guard) this validation will be skipped.

For e2e tests on k8s a fake PDB will be created.

Replaces #76 

```release-note
Added master quorum validation
```