### PR TITLE
Fixed namespace of etcd-quorum-guard PDB

### DIFF
--- a/pkg/apis/nodemaintenance/v1beta1/nodemaintenance_validator.go
+++ b/pkg/apis/nodemaintenance/v1beta1/nodemaintenance_validator.go
@@ -23,7 +23,7 @@ const (
 
 const (
 	EtcdQuorumPDBName      = "etcd-quorum-guard"
-	EtcdQuorumPDBNamespace = "openshift-machine-config-operator"
+	EtcdQuorumPDBNamespace = "openshift-etcd"
 	LabelNameRoleMaster    = "node-role.kubernetes.io/master"
 )
 

--- a/test/manifests/fake-etcd-quorum-guard.yaml
+++ b/test/manifests/fake-etcd-quorum-guard.yaml
@@ -1,14 +1,14 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: openshift-machine-config-operator
+  name: openshift-etcd
   labels:
-    name: openshift-machine-config-operator
+    name: openshift-etcd
 ---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  namespace: openshift-machine-config-operator
+  namespace: openshift-etcd
   name: etcd-quorum-guard
 spec:
   maxUnavailable: 0


### PR DESCRIPTION
The etcd-quorum-guard moved from `openshift-machine-config-operator` to `openshift-etcd`

```release-note
NONE
```