### PR TITLE
Fix e2e test

### DIFF
--- a/hack/functest.sh
+++ b/hack/functest.sh
@@ -31,9 +31,8 @@ else
         # so we create a fake etcd-quorum-guard PDB with maxUnavailable = 0, which will always result in disruptionsAllowed = 0 without a corresponding deployment
         # that will make node maintenance requests for master nodes always fail
         $CLUSTER_COMMAND apply -f test/manifests/fake-etcd-quorum-guard.yaml
+        OPERATOR_NS=node-maintenance
     fi
-
-    OPERATOR_NS=node-maintenance
 
 fi
 

--- a/hack/sync-deploy.sh
+++ b/hack/sync-deploy.sh
@@ -108,6 +108,10 @@ until [[ $success -eq 1 ]] || [[ $iterations -eq $max_iterations ]]; do
     else
         # All resources deployed successfully
         success=1
+        # Fixme Webhook setup is slow... service needs to be created, endpoint needs to be created, and webhook server must be running
+        # Didn't find an easy but good solution yet, so just wait a bit for now
+        echo "[INFO] Giving the webhook some time to setup"
+        sleep 30s
     fi
     set -e
 

--- a/test/e2e/nodemaintenance_test.go
+++ b/test/e2e/nodemaintenance_test.go
@@ -234,7 +234,10 @@ func enterAndExitMaintenanceMode(t *testing.T) error {
 			}
 		} else {
 			t.Fatalf("unexpexted nr of master nodes, can't run master quorum validation test")
+			break
 		}
+		// the etcd-quorum-guard PDB needs some time to be updated...
+		time.Sleep(10 * time.Second)
 	}
 
 	err = createSimpleDeployment(t, namespace)

--- a/test/e2e/nodemaintenance_test.go
+++ b/test/e2e/nodemaintenance_test.go
@@ -88,8 +88,8 @@ func showDeploymentStatus(t *testing.T, callerError error) {
 
 func checkValidLease(t *testing.T, nodeName string) error {
 
-	// FIXME this won't work: nmo.LeaseNamespace is overwritten by the operator during runtime, and we will never see that here...
-	nName := types.NamespacedName{Namespace: nmo.LeaseNamespace, Name: nodeName}
+	ns := os.Getenv("OPERATOR_NS")
+	nName := types.NamespacedName{Namespace: ns, Name: nodeName}
 	lease := &coordv1beta1.Lease{}
 	err := Client.Get(context.TODO(), nName, lease)
 	if err != nil {
@@ -122,7 +122,8 @@ func checkValidLease(t *testing.T, nodeName string) error {
 }
 
 func checkInvalidLease(t *testing.T, nodeName string) error {
-	nName := types.NamespacedName{Namespace: nmo.LeaseNamespace, Name: nodeName}
+	ns := os.Getenv("OPERATOR_NS")
+	nName := types.NamespacedName{Namespace: ns, Name: nodeName}
 	lease := &coordv1beta1.Lease{}
 	err := Client.Get(context.TODO(), nName, lease)
 	if err != nil {

--- a/test/e2e/nodemaintenance_test.go
+++ b/test/e2e/nodemaintenance_test.go
@@ -44,8 +44,8 @@ func getCurrentOperatorPods() (*corev1.Pod, error) {
 		return nil, err
 	}
 
-	if pods.Size() == 0 {
-		return nil, fmt.Errorf("There are no pods deployed in cluster to run the operator")
+	if len(pods.Items) == 0 {
+		return nil, fmt.Errorf("no NMO pod found in ns %s", ns)
 	}
 
 	return &pods.Items[0], nil


### PR DESCRIPTION
Running the e2e test on OpenshiftCI revealed some issues:
- putting master nodes into maintenance at (nearly) the same time won't be prevented by the master quorum validation, because the etcd-quorum-guard PDB isn't updated fats enough.
- the lease was expected in the wrong namespace
- seems the webhook setup is slower, so wait a bit after NMO deployment (update to a better solution when https://github.com/kubernetes-sigs/controller-runtime/issues/723 is fixed)