### PR TITLE
Allow ownNamespace installMode

### DIFF
--- a/deploy/deployment-k8s/operatorgroup.yaml
+++ b/deploy/deployment-k8s/operatorgroup.yaml
@@ -3,3 +3,6 @@ kind: OperatorGroup
 metadata:
   name: node-maintenance-operator
   namespace: node-maintenance
+spec:
+  targetNamespaces:
+    - node-maintenance

--- a/deploy/deployment-ocp/operatorgroup.yaml
+++ b/deploy/deployment-ocp/operatorgroup.yaml
@@ -3,3 +3,6 @@ kind: OperatorGroup
 metadata:
   name: node-maintenance-operator
   namespace: openshift-node-maintenance-operator
+spec:
+  targetNamespaces:
+    - openshift-node-maintenance-operator

--- a/deploy/olm-catalog/node-maintenance-operator/manifests/node-maintenance-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/node-maintenance-operator/manifests/node-maintenance-operator.clusterserviceversion.yaml
@@ -170,7 +170,7 @@ spec:
                 key: node-role.kubernetes.io/master
     strategy: deployment
   installModes:
-  - supported: false
+  - supported: true
     type: OwnNamespace
   - supported: false
     type: SingleNamespace

--- a/deploy/operatorgroup.yaml
+++ b/deploy/operatorgroup.yaml
@@ -3,3 +3,6 @@ kind: OperatorGroup
 metadata:
   name: node-maintenance-operator
   namespace: SUBSCRIPTION_NAMESPACE
+spec:
+  targetNamespaces:
+    - SUBSCRIPTION_NAMESPACE

--- a/hack/sync-deploy.sh
+++ b/hack/sync-deploy.sh
@@ -111,7 +111,7 @@ until [[ $success -eq 1 ]] || [[ $iterations -eq $max_iterations ]]; do
         # Fixme Webhook setup is slow... service needs to be created, endpoint needs to be created, and webhook server must be running
         # Didn't find an easy but good solution yet, so just wait a bit for now
         echo "[INFO] Giving the webhook some time to setup"
-        sleep 30s
+        sleep 60s
     fi
     set -e
 

--- a/manifests/node-maintenance-operator/template/node-maintenance-operator.clusterserviceversion.yaml
+++ b/manifests/node-maintenance-operator/template/node-maintenance-operator.clusterserviceversion.yaml
@@ -163,7 +163,7 @@ spec:
                 key: node-role.kubernetes.io/master
     strategy: deployment
   installModes:
-  - supported: false
+  - supported: true
     type: OwnNamespace
   - supported: false
     type: SingleNamespace

--- a/manifests/node-maintenance-operator/v0.7.0/manifests/node-maintenance-operator.clusterserviceversion.yaml
+++ b/manifests/node-maintenance-operator/v0.7.0/manifests/node-maintenance-operator.clusterserviceversion.yaml
@@ -170,7 +170,7 @@ spec:
                 key: node-role.kubernetes.io/master
     strategy: deployment
   installModes:
-  - supported: false
+  - supported: true
     type: OwnNamespace
   - supported: false
     type: SingleNamespace

--- a/manifests/node-maintenance-operator/v9.9.9/manifests/node-maintenance-operator.clusterserviceversion.yaml
+++ b/manifests/node-maintenance-operator/v9.9.9/manifests/node-maintenance-operator.clusterserviceversion.yaml
@@ -170,7 +170,7 @@ spec:
                 key: node-role.kubernetes.io/master
     strategy: deployment
   installModes:
-  - supported: false
+  - supported: true
     type: OwnNamespace
   - supported: false
     type: SingleNamespace


### PR DESCRIPTION
Background: HCO is switching from deploying NMO itself to making NMO a dependency only. HCO uses the ownNamespace installMode, and because of that OLM tries to install NMO in ownNamespace mode as well, which isn't allowed so far and makes the deployment fail.

With this PR NMO allows ownNamespace installMode. But that also has an issue: webhooks are misconfigured by OLM, cluster scoped resources would not be handled. So a workaround for this is added as well.

```release-note
Allow ownNamespace installMode
```