### PR TITLE
Switch from leader-for-life to leader-with-lease

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -24,7 +24,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
-	"github.com/operator-framework/operator-sdk/pkg/leader"
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
 	"github.com/operator-framework/operator-sdk/pkg/metrics"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
@@ -97,20 +96,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	ctx := context.TODO()
-
-	// Become the leader before proceeding
-	err = leader.Become(ctx, "node-maintenance-operator-lock")
-	if err != nil {
-		log.Error(err, "")
-		os.Exit(1)
-	}
-
 	nodemaintenance.SetLeaseNamespace(namespace)
 
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := manager.New(cfg, manager.Options{
 		MetricsBindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),
+		LeaderElection:     true,
+		LeaderElectionID:   "node-maintenance-operator-lock",
 	})
 	if err != nil {
 		log.Error(err, "")


### PR DESCRIPTION
The latter works better with evicted pods, and since NMO actively evicts
pods, there is some chance that it evicts itself as well.
See https://sdk.operatorframework.io/docs/building-operators/golang/advanced-topics/#leader-election

```release-note
Switch from leader-for-life to leader-with-lease
```