### PR TITLE
Add some useful version info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,12 @@ KUBEVIRTCI_PATH=$$(pwd)/kubevirtci/cluster-up
 KUBEVIRTCI_CONFIG_PATH=$$(pwd)/_ci-configs
 export KUBEVIRT_NUM_NODES ?= 3
 
+GIT_VERSION=$$(git describe --always --tags)
+VERSION=$${CI_UPSTREAM_VERSION:-$(GIT_VERSION)}
+GIT_COMMIT=$$(git rev-list -1 HEAD)
+COMMIT=$${CI_UPSTREAM_COMMIT:-$(GIT_COMMIT)}
+BUILD_DATE=$$(date --utc -Iseconds)
+
 export GINKGO ?= build/_output/bin/ginkgo
 
 # Make does not offer a recursive wildcard function, so here's one:
@@ -72,7 +78,12 @@ check: shfmt fmt vet generate-all verify-manifests verify-unchanged test
 
 .PHONY: build
 build:
-	mkdir -p _out && GOFLAGS=-mod=vendor CGO_ENABLED=0 GOOS=linux go build -o _out/node-maintenance-operator kubevirt.io/node-maintenance-operator/cmd/manager
+	mkdir -p _out; \
+	LDFLAGS="-s -w "; \
+	LDFLAGS+="-X kubevirt.io/node-maintenance-operator/version.Version=$(VERSION) "; \
+	LDFLAGS+="-X kubevirt.io/node-maintenance-operator/version.GitCommit=$(COMMIT) "; \
+	LDFLAGS+="-X kubevirt.io/node-maintenance-operator/version.BuildDate=$(BUILD_DATE) "; \
+	GOFLAGS=-mod=vendor CGO_ENABLED=0 GOOS=linux go build -ldflags="$$LDFLAGS" -o _out/node-maintenance-operator kubevirt.io/node-maintenance-operator/cmd/manager
 
 .PHONY: container-build
 container-build: container-build-operator container-build-bundle container-build-index container-build-must-gather

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -8,15 +8,14 @@ import (
 	"path/filepath"
 	"runtime"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	"github.com/spf13/pflag"
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
@@ -32,6 +31,7 @@ import (
 	"kubevirt.io/node-maintenance-operator/pkg/apis/nodemaintenance/v1beta1"
 	"kubevirt.io/node-maintenance-operator/pkg/controller"
 	"kubevirt.io/node-maintenance-operator/pkg/controller/nodemaintenance"
+	"kubevirt.io/node-maintenance-operator/version"
 )
 
 // Change below variables to serve metrics on different host or port.
@@ -58,6 +58,9 @@ func printVersion() {
 	log.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
 	log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
 	log.Info(fmt.Sprintf("Version of operator-sdk: %v", sdkVersion.Version))
+	log.Info(fmt.Sprintf("Operator Version: %s", version.Version))
+	log.Info(fmt.Sprintf("Git Commit: %s", version.GitCommit))
+	log.Info(fmt.Sprintf("Build Date: %s", version.BuildDate))
 }
 
 func main() {

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,10 @@
 package version
 
 var (
+	// Version is the operator version
 	Version = "0.0.1"
+	// GitCommit is the current git commit hash
+	GitCommit = "n/a"
+	// BuildDate is the build date
+	BuildDate = "n/a"
 )


### PR DESCRIPTION
Git version, commit hash and build date: 

```
$ ./_out/node-maintenance-operator
...
{"level":"info","ts":1598949801.267715,"logger":"cmd","msg":"Operator Version: v0.6.0-102-g3937d3d5"}
{"level":"info","ts":1598949801.2677214,"logger":"cmd","msg":"Git Commit: 3937d3d5cfa3558526782680766e5ce87a58f630"}
{"level":"info","ts":1598949801.2677276,"logger":"cmd","msg":"Build Date: 2020-09-01T08:43:15+00:00"}
...
```

```release-note
Added Git version, commit hash and build date to version info
```