### PR TITLE
Re-added csv-generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ test:
 shfmt:
 	go get mvdan.cc/sh/v3/cmd/shfmt
 	shfmt -i 4 -w ./hack/
+	shfmt -i 4 -w ./build/
 
 .PHONY: check
 check: shfmt fmt vet generate-all verify-manifests verify-unchanged test

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -17,6 +17,11 @@ COPY --from=builder /go/src/kubevirt.io/node-maintenance-operator/_out/node-main
 COPY --from=builder /go/src/kubevirt.io/node-maintenance-operator/build/bin /usr/local/bin
 RUN  /usr/local/bin/user_setup
 
+# needed for HCO
+LABEL org.kubevirt.hco.csv-generator.v1="/usr/local/bin/csv-generator"
+COPY --from=builder /go/src/kubevirt.io/node-maintenance-operator/build/hco/csv-generator /usr/local/bin/
+COPY --from=builder /go/src/kubevirt.io/node-maintenance-operator/manifests/node-maintenance-operator/v9.9.9/manifests /manifests
+
 ENTRYPOINT ["/usr/local/bin/entrypoint"]
 
 USER ${USER_UID}

--- a/build/bin/user_setup
+++ b/build/bin/user_setup
@@ -2,7 +2,7 @@
 set -x
 
 # ensure $HOME exists and is accessible by group 0 (we don't know what the runtime UID will be)
-echo "${USER_NAME}:x:${USER_UID}:0:${USER_NAME} user:${HOME}:/sbin/nologin" >> /etc/passwd
+echo "${USER_NAME}:x:${USER_UID}:0:${USER_NAME} user:${HOME}:/sbin/nologin" >>/etc/passwd
 mkdir -p "${HOME}"
 chown "${USER_UID}:0" "${HOME}"
 chmod ug+rwx "${HOME}"

--- a/build/hco/csv-generator
+++ b/build/hco/csv-generator
@@ -30,9 +30,9 @@ OPERATOR_IMAGE=""
 # OPTIONAL ARGS
 WATCH_NAMESPACE=""
 
-while (( "$#" )); do
-    ARG=`echo $1 | awk -F= '{print $1}'`
-    VAL=`echo $1 | awk -F= '{print $2}'`
+while (("$#")); do
+    ARG=$(echo $1 | awk -F= '{print $1}')
+    VAL=$(echo $1 | awk -F= '{print $2}')
     shift
 
     case "$ARG" in
@@ -78,7 +78,7 @@ echo "---"
 cat ${TMP_CSV}
 rm ${TMP_CSV}
 if [ "$DUMP_CRDS" = "true" ]; then
-    for CRD in $( ls ${MANIFESTS_DIR}/*crd.yaml ); do
+    for CRD in $(ls ${MANIFESTS_DIR}/*crd.yaml); do
         echo "---"
         cat ${CRD}
     done

--- a/build/hco/csv-generator
+++ b/build/hco/csv-generator
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+set -e
+
+MANIFESTS_DIR="manifests/node-maintenance-operator/v9.9.9/manifests"
+if ! [ -d $MANIFESTS_DIR ]; then
+    # we are in the docker image
+    MANIFESTS_DIR="/manifests"
+fi
+
+TEMPLATE_CSV=${MANIFESTS_DIR}/node-maintenance-operator.clusterserviceversion.yaml
+TMP_CSV=$(mktemp)
+
+help_text() {
+    echo "USAGE: csv-generator --csv-version=<version> --namespace=<namespace> --operator-image=<operator image> [optional args]"
+    echo ""
+    echo "ARGS:"
+    echo "  --csv-version:    (REQUIRED) The version of the CSV file"
+    echo "  --namespace:      (REQUIRED) The namespace set on the CSV file"
+    echo "  --operator-image: (REQUIRED) The operator container image to use in the CSV file"
+    echo "  --watch-namespace:   (OPTIONAL)"
+    echo "  --dump-crds:         (OPTIONAL) Dumps CRD manifests with the CSV to stdout"
+}
+
+# REQUIRED ARGS
+CSV_VERSION=""
+NAMESPACE=""
+OPERATOR_IMAGE=""
+
+# OPTIONAL ARGS
+WATCH_NAMESPACE=""
+
+while (( "$#" )); do
+    ARG=`echo $1 | awk -F= '{print $1}'`
+    VAL=`echo $1 | awk -F= '{print $2}'`
+    shift
+
+    case "$ARG" in
+    --csv-version)
+        CSV_VERSION=$VAL
+        ;;
+    --namespace)
+        NAMESPACE=$VAL
+        ;;
+    --operator-image)
+        OPERATOR_IMAGE=$VAL
+        ;;
+    --watch-namespace)
+        WATCH_NAMESPACE=$VAL
+        ;;
+    --dump-crds)
+        DUMP_CRDS="true"
+        ;;
+    --)
+        break
+        ;;
+    *) # unsupported flag
+        echo "Error: Unsupported flag $ARG" >&2
+        exit 1
+        ;;
+    esac
+done
+
+if [ -z "$CSV_VERSION" ] || [ -z "$NAMESPACE" ] || [ -z "$OPERATOR_IMAGE" ]; then
+    echo "Error: Missing required arguments"
+    help_text
+    exit 1
+fi
+
+# make a copy of the template and replace all needed values
+cp ${TEMPLATE_CSV} ${TMP_CSV}
+sed -i "s/9.9.9/${CSV_VERSION}/g" ${TMP_CSV}
+sed -i "s/namespace: placeholder/namespace: ${NAMESPACE}/g" ${TMP_CSV}
+sed -i "s|IMAGE_REGISTRY/OPERATOR_IMAGE:IMAGE_TAG|${OPERATOR_IMAGE}|g" ${TMP_CSV}
+
+# dump CSV and CRD manifests to stdout
+echo "---"
+cat ${TMP_CSV}
+rm ${TMP_CSV}
+if [ "$DUMP_CRDS" = "true" ]; then
+    for CRD in $( ls ${MANIFESTS_DIR}/*crd.yaml ); do
+        echo "---"
+        cat ${CRD}
+    done
+fi

--- a/deploy/crds/nodemaintenance_cr.yaml
+++ b/deploy/crds/nodemaintenance_cr.yaml
@@ -1,7 +1,7 @@
 apiVersion: nodemaintenance.kubevirt.io/v1beta1
 kind: NodeMaintenance
 metadata:
-  name: nodemaintenance-xyz
+  name: nodemaintenance-example
 spec:
   nodeName: node02
   reason: "Test node maintenance"

--- a/deploy/olm-catalog/node-maintenance-operator/manifests/node-maintenance-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/node-maintenance-operator/manifests/node-maintenance-operator.clusterserviceversion.yaml
@@ -8,7 +8,7 @@ metadata:
           "apiVersion": "nodemaintenance.kubevirt.io/v1beta1",
           "kind": "NodeMaintenance",
           "metadata": {
-            "name": "nodemaintenance-xyz"
+            "name": "nodemaintenance-example"
           },
           "spec": {
             "nodeName": "node02",
@@ -182,7 +182,7 @@ spec:
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
-  - supported: true
+  - supported: false
     type: AllNamespaces
   keywords:
   - KubeVirt

--- a/go.sum
+++ b/go.sum
@@ -1345,6 +1345,7 @@ modernc.org/strutil v1.0.0/go.mod h1:lstksw84oURvj9y3tn8lGvRxyRC1S2+g5uuIzNfIOBs
 modernc.org/xc v1.0.0/go.mod h1:mRNCo0bvLjGhHO9WsyuKVU4q0ceiDDDoEeWDJHrNx8I=
 mvdan.cc/editorconfig v0.1.1-0.20200121172147-e40951bde157 h1:VBYz8greWWP8BDpRX0v7SDv/8rNlZVmdHdO4ZSsHj/E=
 mvdan.cc/editorconfig v0.1.1-0.20200121172147-e40951bde157/go.mod h1:Ge4atmRUYqueGppvJ7JNrtqpqokoJEFxYbP0Z+WeKS8=
+mvdan.cc/sh v1.3.1 h1:UxMLpJPEnVj8hmGWCD3kgC5Toem3A3VuDliExsENI7E=
 mvdan.cc/sh v2.6.4+incompatible h1:eD6tDeh0pw+/TOTI1BBEryZ02rD2nMcFsgcvde7jffM=
 mvdan.cc/sh/v3 v3.1.2 h1:PG5BYlwtrkZTbJXUy25r0/q9shB5ObttCaknkOIB1XQ=
 mvdan.cc/sh/v3 v3.1.2/go.mod h1:F+Vm4ZxPJxDKExMLhvjuI50oPnedVXpfjNSrusiTOno=

--- a/manifests/node-maintenance-operator/template/node-maintenance-operator.clusterserviceversion.yaml
+++ b/manifests/node-maintenance-operator/template/node-maintenance-operator.clusterserviceversion.yaml
@@ -175,7 +175,7 @@ spec:
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
-  - supported: true
+  - supported: false
     type: AllNamespaces
   keywords:
   - KubeVirt

--- a/manifests/node-maintenance-operator/v0.7.0/manifests/node-maintenance-operator.clusterserviceversion.yaml
+++ b/manifests/node-maintenance-operator/v0.7.0/manifests/node-maintenance-operator.clusterserviceversion.yaml
@@ -8,7 +8,7 @@ metadata:
           "apiVersion": "nodemaintenance.kubevirt.io/v1beta1",
           "kind": "NodeMaintenance",
           "metadata": {
-            "name": "nodemaintenance-xyz"
+            "name": "nodemaintenance-example"
           },
           "spec": {
             "nodeName": "node02",
@@ -182,7 +182,7 @@ spec:
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
-  - supported: true
+  - supported: false
     type: AllNamespaces
   keywords:
   - KubeVirt

--- a/manifests/node-maintenance-operator/v9.9.9/manifests/node-maintenance-operator.clusterserviceversion.yaml
+++ b/manifests/node-maintenance-operator/v9.9.9/manifests/node-maintenance-operator.clusterserviceversion.yaml
@@ -8,7 +8,7 @@ metadata:
           "apiVersion": "nodemaintenance.kubevirt.io/v1beta1",
           "kind": "NodeMaintenance",
           "metadata": {
-            "name": "nodemaintenance-xyz"
+            "name": "nodemaintenance-example"
           },
           "spec": {
             "nodeName": "node02",
@@ -182,7 +182,7 @@ spec:
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
-  - supported: true
+  - supported: false
     type: AllNamespaces
   keywords:
   - KubeVirt


### PR DESCRIPTION
Since NMO continues to be delivered as part of HCO we needed to re-add the csv-generator script, also we don't need to support the allNamespaces installMode for this version

```release-note
NONE
```