### PR TITLE
Bug 1895033: Remove master node affinity

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+# ignore all hidden files in root (e.g. .idea)
+./.*

--- a/Makefile
+++ b/Makefile
@@ -68,8 +68,12 @@ shfmt:
 	shfmt -i 4 -w ./hack/
 	shfmt -i 4 -w ./build/
 
+.PHONY: check-all
+check-all: shfmt fmt vet generate-all verify-manifests verify-unchanged test
+
 .PHONY: check
-check: shfmt fmt vet generate-all verify-manifests verify-unchanged test
+check:
+	docker build -f build/check.Dockerfile .
 
 .PHONY: build
 build:

--- a/build/check.Dockerfile
+++ b/build/check.Dockerfile
@@ -1,0 +1,6 @@
+FROM golang:1.13.8 AS builder
+WORKDIR /go/src/kubevirt.io/node-maintenance-operator/
+ENV GOPATH=/go
+COPY . .
+
+RUN make check-all

--- a/deploy/olm-catalog/node-maintenance-operator/manifests/node-maintenance-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/node-maintenance-operator/manifests/node-maintenance-operator.clusterserviceversion.yaml
@@ -147,13 +147,6 @@ spec:
               labels:
                 name: node-maintenance-operator
             spec:
-              affinity:
-                nodeAffinity:
-                  requiredDuringSchedulingIgnoredDuringExecution:
-                    nodeSelectorTerms:
-                    - matchExpressions:
-                      - key: node-role.kubernetes.io/master
-                        operator: Exists
               containers:
               - env:
                 - name: WATCH_NAMESPACE

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -14,13 +14,6 @@ spec:
         name: node-maintenance-operator
     spec:
       serviceAccountName: node-maintenance-operator
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule

--- a/manifests/node-maintenance-operator/v0.8.0/manifests/node-maintenance-operator.clusterserviceversion.yaml
+++ b/manifests/node-maintenance-operator/v0.8.0/manifests/node-maintenance-operator.clusterserviceversion.yaml
@@ -147,13 +147,6 @@ spec:
               labels:
                 name: node-maintenance-operator
             spec:
-              affinity:
-                nodeAffinity:
-                  requiredDuringSchedulingIgnoredDuringExecution:
-                    nodeSelectorTerms:
-                    - matchExpressions:
-                      - key: node-role.kubernetes.io/master
-                        operator: Exists
               containers:
               - env:
                 - name: WATCH_NAMESPACE

--- a/manifests/node-maintenance-operator/v9.9.9/manifests/node-maintenance-operator.clusterserviceversion.yaml
+++ b/manifests/node-maintenance-operator/v9.9.9/manifests/node-maintenance-operator.clusterserviceversion.yaml
@@ -147,13 +147,6 @@ spec:
               labels:
                 name: node-maintenance-operator
             spec:
-              affinity:
-                nodeAffinity:
-                  requiredDuringSchedulingIgnoredDuringExecution:
-                    nodeSelectorTerms:
-                    - matchExpressions:
-                      - key: node-role.kubernetes.io/master
-                        operator: Exists
               containers:
               - env:
                 - name: WATCH_NAMESPACE


### PR DESCRIPTION
CNV uses the subscription to set a node selector, which conflicts with the node affinity.

```release-note
Removed master node affinity
```