### PR TITLE
README change for triggering Sonarcloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Node Maintenance Operator
 
-node-maintenance-operator is an operator generated from the [operator-sdk](https://github.com/operator-framework/operator-sdk).
+The node-maintenance-operator is an operator generated from the [operator-sdk](https://github.com/operator-framework/operator-sdk).
 The purpose of this operator is to watch for new or deleted custom resources called NodeMaintenance which indicate that a node in the cluster should either:
   - NodeMaintenance CR created: move node into maintenance, cordon the node - set it as unschedulable and evict the pods (which can be evicted) from that node.
   - NodeMaintenance CR deleted: remove pod from maintenance and uncordon the node - set it as schedulable

--- a/build/index.Dockerfile.ci.intermediate
+++ b/build/index.Dockerfile.ci.intermediate
@@ -2,7 +2,7 @@ FROM quay.io/operator-framework/upstream-registry-builder
 
 # 9.9.9 points to the templated manifests for CI
 ARG OPERATOR_VERSION_NEXT=9.9.9
-ARG REG_URL=registry.build01.ci.openshift.org
+ARG REG_URL=registry.build02.ci.openshift.org
 
 USER root
 RUN mkdir -p /tmp/manifests


### PR DESCRIPTION
Sonarcloud integration was added by the kubevirt team... let's see what happens

https://sonarcloud.io/project/configuration?id=kubevirt_node-maintenance-operator

/hold