### PR TITLE
Some cleanup after CI updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -269,7 +269,7 @@ catalog-push: ## Push a catalog image.
 ##@ Targets used by CI
 
 .PHONY: check ## Dockerized version of make test
-check: # TODO add all code checks from old version
+check:
 	$(DOCKER_GO) "make test"
 
 .PHONY: verify-unchanged
@@ -284,6 +284,6 @@ container-build: check
 .PHONY: container-push ## Push containers (NOTE: catalog can't be build before bundle was pushed)
 container-push: docker-push bundle-push catalog-build catalog-push
 
-.PHONY: cluster-functest
+.PHONY: cluster-functest ## Run e2e tests in a real cluster
 cluster-functest: ginkgo
 	./hack/functest.sh

--- a/api/v1beta1/nodemaintenance_webhook_test.go
+++ b/api/v1beta1/nodemaintenance_webhook_test.go
@@ -151,8 +151,9 @@ var _ = Describe("NodeMaintenance Validation", func() {
 
 				It("should not be rejected", func() {
 					nm := getTestNMO(existingNodeName)
-					err := nm.ValidateCreate()
-					Expect(err).ToNot(HaveOccurred())
+					Eventually(func() error {
+						return nm.ValidateCreate()
+					}, time.Second, 200*time.Millisecond).ShouldNot(HaveOccurred())
 				})
 
 			})

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -1,4 +1,0 @@
-#!/bin/bash -ex
-
-echo "KubeVirtCI based e2e tests not supported anymore, check OpenshiftCI jobs"
-echo "TODO Update CI config and remove this"

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,1 +1,0 @@
-../Dockerfile

--- a/build/bundle.Dockerfile
+++ b/build/bundle.Dockerfile
@@ -1,1 +1,0 @@
-../bundle.Dockerfile

--- a/build/readme.txt
+++ b/build/readme.txt
@@ -1,1 +1,0 @@
-Remove this dir after updating OpenShift CI Dockerfile locations!


### PR DESCRIPTION
- remove automation dir, was used by KubeVirtCI e2e, which we don't use anymore
- remove build dir, OpenshiftCI uses correct Dockerfile locations now
- remove outdated comment in Makefile

don't merge before
https://github.com/kubevirt/project-infra/pull/1650
https://github.com/openshift/release/pull/22504

/hold