### PR TITLE
Add annotation to support disconnected mode

### DIFF
--- a/bundle/manifests/node-maintenance-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/node-maintenance-operator.clusterserviceversion.yaml
@@ -19,6 +19,7 @@ metadata:
     capabilities: Basic Install
     categories: OpenShift Optional
     description: Node Maintenance Operator for cordoning and draining nodes.
+    operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/builder: operator-sdk-v1.11.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/kubevirt/node-maintenance-operator

--- a/config/manifests/bases/node-maintenance-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/node-maintenance-operator.clusterserviceversion.yaml
@@ -6,6 +6,7 @@ metadata:
     capabilities: Basic Install
     categories: OpenShift Optional
     description: Node Maintenance Operator for cordoning and draining nodes.
+    operators.openshift.io/infrastructure-features: '["disconnected"]'
     repository: https://github.com/kubevirt/node-maintenance-operator
   name: node-maintenance-operator.v0.0.0
   namespace: placeholder


### PR DESCRIPTION
Adding `'["disconnected"]'` label to `config/manifests/bases/node-maintenance-operator.clusterserviceversion.yaml` file, and then running  `make bundle` to support disconnected environment with NMO.

```release-note
Add annotation to support disconnected mode
```