### PR TITLE
Update Dockerfile to use centos:stream9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM quay.io/centos/centos:stream8 AS builder
+FROM quay.io/centos/centos:stream9 AS builder
 RUN dnf install git golang -y
 
 # Ensure go 1.16


### PR DESCRIPTION
CentOS Stream 8 is now scheduled for EOL as stated in https://www.centos.org/centos-stream/.
Therefore this PR updates CentOS version in Dockerfile for new builds to use CentOS Stream 9, which is in full support phase.

**Release note**:
```release-note
Update Dockerfile to use CentOS Stream 9
```

Signed-off-by: João Vilaça <jvilaca@redhat.com>