### PR TITLE
Fix: Error: short-name resolution enforced but cannot prompt without …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ export DOCKER_GO=docker run --rm -v $$(pwd):/home/go/src/kubevirt.io/node-mainte
 	-u $$(id -u) -w /home/go/src/kubevirt.io/node-maintenance-operator \
 	-e "GOPATH=/go" -e "GOFLAGS=-mod=vendor" -e "XDG_CACHE_HOME=/tmp/.cache" \
 	-e "VERSION=$(VERSION)" -e "IMAGE_REGISTRY=$(IMAGE_REGISTRY)" \
-	--entrypoint /bin/bash golang:$(GO_VERSION) -c
+	--entrypoint /bin/bash docker.io/library/golang:$(GO_VERSION) -c
 
 all: build
 


### PR DESCRIPTION
…a TTY

Currently CI is failing on the error message above. This change provides a long name to docker, to prevent this error.